### PR TITLE
Add custom credential provider support for source & sink connector

### DIFF
--- a/sdk/cosmos/azure-cosmos-kafka-connect/pom.xml
+++ b/sdk/cosmos/azure-cosmos-kafka-connect/pom.xml
@@ -354,6 +354,11 @@ Licensed under the MIT License.
                       <shadedPattern>${shadingPrefix}.com.azure</shadedPattern>
                       <excludes>
                         <exclude>com.azure.cosmos.kafka.**</exclude>
+                        <!-- Minimum for custom credential providers -->
+                        <exclude>com.azure.core.credential.TokenCredential</exclude>
+                        <exclude>com.azure.core.credential.TokenRequestContext</exclude>
+                        <exclude>com.azure.core.credential.AccessToken</exclude>
+                        <exclude>com.azure.core.util.Context</exclude>
                       </excludes>
                     </relocation>
                     <relocation>
@@ -383,10 +388,6 @@ Licensed under the MIT License.
                     <relocation>
                       <pattern>org.HdrHistogram</pattern>
                       <shadedPattern>${shadingPrefix}.org.HdrHistogram</shadedPattern>
-                    </relocation>
-                    <relocation>
-                      <pattern>reactor</pattern>
-                      <shadedPattern>${shadingPrefix}.reactor</shadedPattern>
                     </relocation>
                     <relocation>
                       <pattern>com.jayway.jsonpath</pattern>

--- a/sdk/cosmos/azure-cosmos-kafka-connect/pom.xml
+++ b/sdk/cosmos/azure-cosmos-kafka-connect/pom.xml
@@ -354,11 +354,6 @@ Licensed under the MIT License.
                       <shadedPattern>${shadingPrefix}.com.azure</shadedPattern>
                       <excludes>
                         <exclude>com.azure.cosmos.kafka.**</exclude>
-                        <!-- Minimum for custom credential providers -->
-                        <exclude>com.azure.core.credential.TokenCredential</exclude>
-                        <exclude>com.azure.core.credential.TokenRequestContext</exclude>
-                        <exclude>com.azure.core.credential.AccessToken</exclude>
-                        <exclude>com.azure.core.util.Context</exclude>
                       </excludes>
                     </relocation>
                     <relocation>
@@ -388,6 +383,10 @@ Licensed under the MIT License.
                     <relocation>
                       <pattern>org.HdrHistogram</pattern>
                       <shadedPattern>${shadingPrefix}.org.HdrHistogram</shadedPattern>
+                    </relocation>
+                    <relocation>
+                      <pattern>reactor</pattern>
+                      <shadedPattern>${shadingPrefix}.reactor</shadedPattern>
                     </relocation>
                     <relocation>
                       <pattern>com.jayway.jsonpath</pattern>

--- a/sdk/cosmos/azure-cosmos-kafka-connect/src/main/java/com/azure/cosmos/kafka/connect/implementation/CosmosAuthType.java
+++ b/sdk/cosmos/azure-cosmos-kafka-connect/src/main/java/com/azure/cosmos/kafka/connect/implementation/CosmosAuthType.java
@@ -6,7 +6,7 @@ package com.azure.cosmos.kafka.connect.implementation;
 public enum CosmosAuthType {
     MASTER_KEY("MasterKey"),
     SERVICE_PRINCIPAL("ServicePrincipal"),
-    CUSTOM("Custom");
+    CUSTOM("Custom"); // This can be used for a custom class-based credential provider
 
     private final String name;
 

--- a/sdk/cosmos/azure-cosmos-kafka-connect/src/main/java/com/azure/cosmos/kafka/connect/implementation/CosmosAuthType.java
+++ b/sdk/cosmos/azure-cosmos-kafka-connect/src/main/java/com/azure/cosmos/kafka/connect/implementation/CosmosAuthType.java
@@ -5,7 +5,8 @@ package com.azure.cosmos.kafka.connect.implementation;
 
 public enum CosmosAuthType {
     MASTER_KEY("MasterKey"),
-    SERVICE_PRINCIPAL("ServicePrincipal");
+    SERVICE_PRINCIPAL("ServicePrincipal"),
+    CUSTOM("Custom");
 
     private final String name;
 

--- a/sdk/cosmos/azure-cosmos-kafka-connect/src/main/java/com/azure/cosmos/kafka/connect/implementation/CosmosClientStore.java
+++ b/sdk/cosmos/azure-cosmos-kafka-connect/src/main/java/com/azure/cosmos/kafka/connect/implementation/CosmosClientStore.java
@@ -10,6 +10,7 @@ import com.azure.cosmos.ThrottlingRetryOptions;
 import com.azure.cosmos.implementation.CosmosClientMetadataCachesSnapshot;
 import com.azure.cosmos.implementation.ImplementationBridgeHelpers;
 import com.azure.cosmos.implementation.apachecommons.lang.StringUtils;
+import com.azure.core.credential.TokenCredential;
 import com.azure.identity.ClientSecretCredential;
 import com.azure.identity.ClientSecretCredentialBuilder;
 
@@ -55,8 +56,12 @@ public class CosmosClientStore {
                 .clientSecret(aadAuthConfig.getClientSecret())
                 .build();
             cosmosClientBuilder.credential(tokenCredential);
+        } else if (accountConfig.getCosmosAuthConfig() instanceof CosmosCustomAuthConfig) {
+            CosmosCustomAuthConfig customAuthConfig = (CosmosCustomAuthConfig) accountConfig.getCosmosAuthConfig();
+            TokenCredential tokenCredential = createCustomTokenCredential(customAuthConfig);
+            cosmosClientBuilder.credential(tokenCredential);
         } else {
-            throw new IllegalArgumentException("Authorization type " + accountConfig.getCosmosAuthConfig().getClass() + "is not supported");
+            throw new IllegalArgumentException("Authorization type " + accountConfig.getCosmosAuthConfig().getClass() + " is not supported");
         }
 
         if (snapshot != null) {
@@ -79,5 +84,50 @@ public class CosmosClientStore {
         }
 
         return userAgentSuffix;
+    }
+    /**
+     * Dynamically loads and instantiates a custom credential provider for Cosmos DB authentication.
+     * <p>
+     * The credential provider class specified in {@code customAuthConfig} must:
+     * <ul>
+     *   <li>Implement the {@link com.azure.core.credential.TokenCredential} interface.</li>
+     *   <li>Optionally implement {@link org.apache.kafka.common.Configurable} to receive configuration via {@code configure(Map<String, ?>)}.</li>
+     * </ul>
+     * The class is loaded by name using {@link Class#forName(String)}, instantiated using its public no-argument constructor,
+     * and, if it implements {@code Configurable}, configured with the config map from {@code customAuthConfig}.
+     * <p>
+     * @param customAuthConfig The custom authentication configuration containing the credential provider class name and configuration map.
+     * @return An instance of {@link TokenCredential} for authentication.
+     * @throws IllegalArgumentException If the class name is missing, the class does not implement {@code TokenCredential},
+     *                                 the class cannot be found, or instantiation/configuration fails.
+     */
+    private static TokenCredential createCustomTokenCredential(CosmosCustomAuthConfig customAuthConfig) {
+        String providerClassName = customAuthConfig.getCredentialProviderClass();
+
+        if (providerClassName == null || providerClassName.trim().isEmpty()) {
+            throw new IllegalArgumentException("Credential provider class is required for Custom authentication");
+        }
+
+        try {
+            Class<?> providerClass = Class.forName(providerClassName);
+
+            if (!TokenCredential.class.isAssignableFrom(providerClass)) {
+                throw new IllegalArgumentException("Provider class must implement TokenCredential interface: " + providerClassName);
+            }
+
+            Object provider = providerClass.getConstructor().newInstance();
+
+            if (provider instanceof org.apache.kafka.common.Configurable) {
+                ((org.apache.kafka.common.Configurable) provider).configure(customAuthConfig.getConfigMap());
+            }
+
+            return (TokenCredential) provider;
+        } catch (ClassNotFoundException e) {
+            throw new IllegalArgumentException("Credential provider class not found: " + providerClassName, e);
+        } catch (NoSuchMethodException e) {
+            throw new IllegalArgumentException("Credential provider class must have a public no-argument constructor: " + providerClassName, e);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Failed to create credential provider: " + providerClassName + ". " + e.getMessage(), e);
+        }
     }
 }

--- a/sdk/cosmos/azure-cosmos-kafka-connect/src/main/java/com/azure/cosmos/kafka/connect/implementation/CosmosClientStore.java
+++ b/sdk/cosmos/azure-cosmos-kafka-connect/src/main/java/com/azure/cosmos/kafka/connect/implementation/CosmosClientStore.java
@@ -3,21 +3,23 @@
 
 package com.azure.cosmos.kafka.connect.implementation;
 
+import com.azure.core.credential.TokenCredential;
 import com.azure.cosmos.CosmosAsyncClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import com.azure.cosmos.CosmosClientBuilder;
 import com.azure.cosmos.GatewayConnectionConfig;
 import com.azure.cosmos.ThrottlingRetryOptions;
 import com.azure.cosmos.implementation.CosmosClientMetadataCachesSnapshot;
 import com.azure.cosmos.implementation.ImplementationBridgeHelpers;
 import com.azure.cosmos.implementation.apachecommons.lang.StringUtils;
-import com.azure.core.credential.TokenCredential;
 import com.azure.identity.ClientSecretCredential;
 import com.azure.identity.ClientSecretCredentialBuilder;
+import java.time.Duration;
 import org.apache.kafka.common.Configurable;
 
-import java.time.Duration;
-
 public class CosmosClientStore {
+    private static final Logger logger = LoggerFactory.getLogger(CosmosClientStore.class);
     public static CosmosAsyncClient getCosmosClient(
         CosmosAccountConfig accountConfig,
         String sourceName) {
@@ -110,10 +112,48 @@ public class CosmosClientStore {
         }
 
         try {
-            @SuppressWarnings("unchecked")
-            Class<TokenCredential> providerClass = (Class<TokenCredential>) Class.forName(providerClassName);
+            // Use current thread ClassLoader like S3 connector does
+            ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
+            Class<?> providerClass = Class.forName(providerClassName, true, contextClassLoader);
 
-            TokenCredential provider = providerClass.getConstructor().newInstance();
+            // Add detailed logging for ClassLoader debugging
+            ClassLoader tokenCredentialClassLoader = TokenCredential.class.getClassLoader();
+            ClassLoader providerClassLoader = providerClass.getClassLoader();
+
+            logger.info("=== ClassLoader Debug Info ===");
+            logger.info("Provider class: {}", providerClassName);
+            logger.info("Context ClassLoader: {}", contextClassLoader);
+            logger.info("TokenCredential ClassLoader: {}", tokenCredentialClassLoader);
+            logger.info("Provider ClassLoader: {}", providerClassLoader);
+            logger.info("TokenCredential class: {}", TokenCredential.class);
+            logger.info("Provider class: {}", providerClass);
+
+            // Check interface compatibility before instantiation like S3 connector
+            boolean isAssignable = TokenCredential.class.isAssignableFrom(providerClass);
+            logger.info("isAssignableFrom result: {}", isAssignable);
+
+            if (!isAssignable) {
+                // Additional debug info for the failure case
+                logger.error("=== Interface Check Failed ===");
+                logger.error("TokenCredential interfaces: ");
+                for (Class<?> iface : TokenCredential.class.getInterfaces()) {
+                    logger.error("  - {} (ClassLoader: {})", iface, iface.getClassLoader());
+                }
+                logger.error("Provider interfaces: ");
+                for (Class<?> iface : providerClass.getInterfaces()) {
+                    logger.error("  - {} (ClassLoader: {})", iface, iface.getClassLoader());
+                }
+
+                throw new IllegalArgumentException("Credential provider class must implement TokenCredential interface: " + providerClassName +
+                    ". TokenCredential ClassLoader: " + tokenCredentialClassLoader +
+                    ", Provider ClassLoader: " + providerClassLoader);
+            }
+
+            @SuppressWarnings("unchecked")
+            Class<TokenCredential> tokenCredentialClass = (Class<TokenCredential>) providerClass;
+            TokenCredential provider = tokenCredentialClass.getConstructor().newInstance();
+
+            logger.info("Provider instantiated successfully: {}", provider.getClass());
 
             if (provider instanceof Configurable) {
                 ((Configurable) provider).configure(customAuthConfig.getConfigMap());
@@ -121,10 +161,16 @@ public class CosmosClientStore {
 
             return provider;
         } catch (ClassNotFoundException e) {
+            logger.error("Class not found: {}", providerClassName, e);
             throw new IllegalArgumentException("Credential provider class not found: " + providerClassName, e);
         } catch (NoSuchMethodException e) {
+            logger.error("No public no-arg constructor: {}", providerClassName, e);
             throw new IllegalArgumentException("Credential provider class must have a public no-argument constructor: " + providerClassName, e);
+        } catch (ClassCastException e) {
+            logger.error("ClassCastException: Cast failed even after isAssignableFrom check passed! This confirms ClassLoader isolation issue", e);
+            throw new IllegalArgumentException("ClassLoader isolation prevents casting to TokenCredential: " + providerClassName + ". " + e.getMessage(), e);
         } catch (Exception e) {
+            logger.error("Unexpected exception creating credential provider {}: {}", providerClassName, e.getMessage(), e);
             throw new IllegalArgumentException("Failed to create credential provider: " + providerClassName + ". " + e.getMessage(), e);
         }
     }

--- a/sdk/cosmos/azure-cosmos-kafka-connect/src/main/java/com/azure/cosmos/kafka/connect/implementation/CosmosClientStore.java
+++ b/sdk/cosmos/azure-cosmos-kafka-connect/src/main/java/com/azure/cosmos/kafka/connect/implementation/CosmosClientStore.java
@@ -13,6 +13,7 @@ import com.azure.cosmos.implementation.apachecommons.lang.StringUtils;
 import com.azure.core.credential.TokenCredential;
 import com.azure.identity.ClientSecretCredential;
 import com.azure.identity.ClientSecretCredentialBuilder;
+import org.apache.kafka.common.Configurable;
 
 import java.time.Duration;
 
@@ -109,19 +110,16 @@ public class CosmosClientStore {
         }
 
         try {
-            Class<?> providerClass = Class.forName(providerClassName);
+            @SuppressWarnings("unchecked")
+            Class<TokenCredential> providerClass = (Class<TokenCredential>) Class.forName(providerClassName);
 
-            if (!TokenCredential.class.isAssignableFrom(providerClass)) {
-                throw new IllegalArgumentException("Provider class must implement TokenCredential interface: " + providerClassName);
+            TokenCredential provider = providerClass.getConstructor().newInstance();
+
+            if (provider instanceof Configurable) {
+                ((Configurable) provider).configure(customAuthConfig.getConfigMap());
             }
 
-            Object provider = providerClass.getConstructor().newInstance();
-
-            if (provider instanceof org.apache.kafka.common.Configurable) {
-                ((org.apache.kafka.common.Configurable) provider).configure(customAuthConfig.getConfigMap());
-            }
-
-            return (TokenCredential) provider;
+            return provider;
         } catch (ClassNotFoundException e) {
             throw new IllegalArgumentException("Credential provider class not found: " + providerClassName, e);
         } catch (NoSuchMethodException e) {

--- a/sdk/cosmos/azure-cosmos-kafka-connect/src/main/java/com/azure/cosmos/kafka/connect/implementation/CosmosClientStore.java
+++ b/sdk/cosmos/azure-cosmos-kafka-connect/src/main/java/com/azure/cosmos/kafka/connect/implementation/CosmosClientStore.java
@@ -5,8 +5,6 @@ package com.azure.cosmos.kafka.connect.implementation;
 
 import com.azure.core.credential.TokenCredential;
 import com.azure.cosmos.CosmosAsyncClient;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import com.azure.cosmos.CosmosClientBuilder;
 import com.azure.cosmos.GatewayConnectionConfig;
 import com.azure.cosmos.ThrottlingRetryOptions;
@@ -19,7 +17,6 @@ import java.time.Duration;
 import org.apache.kafka.common.Configurable;
 
 public class CosmosClientStore {
-    private static final Logger logger = LoggerFactory.getLogger(CosmosClientStore.class);
     public static CosmosAsyncClient getCosmosClient(
         CosmosAccountConfig accountConfig,
         String sourceName) {
@@ -112,48 +109,10 @@ public class CosmosClientStore {
         }
 
         try {
-            // Use current thread ClassLoader like S3 connector does
-            ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
-            Class<?> providerClass = Class.forName(providerClassName, true, contextClassLoader);
-
-            // Add detailed logging for ClassLoader debugging
-            ClassLoader tokenCredentialClassLoader = TokenCredential.class.getClassLoader();
-            ClassLoader providerClassLoader = providerClass.getClassLoader();
-
-            logger.info("=== ClassLoader Debug Info ===");
-            logger.info("Provider class: {}", providerClassName);
-            logger.info("Context ClassLoader: {}", contextClassLoader);
-            logger.info("TokenCredential ClassLoader: {}", tokenCredentialClassLoader);
-            logger.info("Provider ClassLoader: {}", providerClassLoader);
-            logger.info("TokenCredential class: {}", TokenCredential.class);
-            logger.info("Provider class: {}", providerClass);
-
-            // Check interface compatibility before instantiation like S3 connector
-            boolean isAssignable = TokenCredential.class.isAssignableFrom(providerClass);
-            logger.info("isAssignableFrom result: {}", isAssignable);
-
-            if (!isAssignable) {
-                // Additional debug info for the failure case
-                logger.error("=== Interface Check Failed ===");
-                logger.error("TokenCredential interfaces: ");
-                for (Class<?> iface : TokenCredential.class.getInterfaces()) {
-                    logger.error("  - {} (ClassLoader: {})", iface, iface.getClassLoader());
-                }
-                logger.error("Provider interfaces: ");
-                for (Class<?> iface : providerClass.getInterfaces()) {
-                    logger.error("  - {} (ClassLoader: {})", iface, iface.getClassLoader());
-                }
-
-                throw new IllegalArgumentException("Credential provider class must implement TokenCredential interface: " + providerClassName +
-                    ". TokenCredential ClassLoader: " + tokenCredentialClassLoader +
-                    ", Provider ClassLoader: " + providerClassLoader);
-            }
-
             @SuppressWarnings("unchecked")
-            Class<TokenCredential> tokenCredentialClass = (Class<TokenCredential>) providerClass;
-            TokenCredential provider = tokenCredentialClass.getConstructor().newInstance();
-
-            logger.info("Provider instantiated successfully: {}", provider.getClass());
+            Class<TokenCredential> providerClass = (Class<TokenCredential>) Class.forName(providerClassName);
+            
+            TokenCredential provider = providerClass.getConstructor().newInstance();
 
             if (provider instanceof Configurable) {
                 ((Configurable) provider).configure(customAuthConfig.getConfigMap());
@@ -161,16 +120,16 @@ public class CosmosClientStore {
 
             return provider;
         } catch (ClassNotFoundException e) {
-            logger.error("Class not found: {}", providerClassName, e);
             throw new IllegalArgumentException("Credential provider class not found: " + providerClassName, e);
         } catch (NoSuchMethodException e) {
-            logger.error("No public no-arg constructor: {}", providerClassName, e);
             throw new IllegalArgumentException("Credential provider class must have a public no-argument constructor: " + providerClassName, e);
         } catch (ClassCastException e) {
-            logger.error("ClassCastException: Cast failed even after isAssignableFrom check passed! This confirms ClassLoader isolation issue", e);
-            throw new IllegalArgumentException("ClassLoader isolation prevents casting to TokenCredential: " + providerClassName + ". " + e.getMessage(), e);
+            throw new IllegalArgumentException(
+                "Credential provider class " + providerClassName + " cannot be cast to TokenCredential. " +
+                "This can happen if: 1) The class doesn't implement TokenCredential interface, or " +
+                "2) The class implements TokenCredential but from a different classloader (shaded dependencies). " +
+                "Error: " + e.getMessage(), e);
         } catch (Exception e) {
-            logger.error("Unexpected exception creating credential provider {}: {}", providerClassName, e.getMessage(), e);
             throw new IllegalArgumentException("Failed to create credential provider: " + providerClassName + ". " + e.getMessage(), e);
         }
     }

--- a/sdk/cosmos/azure-cosmos-kafka-connect/src/main/java/com/azure/cosmos/kafka/connect/implementation/CosmosCustomAuthConfig.java
+++ b/sdk/cosmos/azure-cosmos-kafka-connect/src/main/java/com/azure/cosmos/kafka/connect/implementation/CosmosCustomAuthConfig.java
@@ -1,0 +1,56 @@
+package com.azure.cosmos.kafka.connect.implementation;
+
+import java.util.Map;
+
+/**
+ * Configuration class for custom authentication with Azure Cosmos DB in Kafka Connect.
+ * <p>
+ * This class allows users to specify a custom {@link com.azure.core.credential.TokenCredential}
+ * implementation for authenticating with Azure Cosmos DB. The custom credential provider class
+ * must meet the following requirements:
+ * <ul>
+ *   <li>Implement the {@link com.azure.core.credential.TokenCredential} interface</li>
+ *   <li>Have a public no-argument constructor</li>
+ *   <li>Optionally implement {@link org.apache.kafka.common.Configurable} to receive configuration parameters</li>
+ * </ul>
+ * </p>
+ *
+ * <p>
+ * Example usage:
+ * </p>
+ * <pre>{@code
+ * Map<String, Object> customConfig = new HashMap<>();
+ * customConfig.put("customProperty", "value");
+ *
+ * CosmosCustomAuthConfig authConfig = new CosmosCustomAuthConfig(
+ *     "com.example.MyCustomTokenCredential",
+ *     customConfig
+ * );
+ * }</pre>
+ *
+ * <p>
+ * If the credential provider class implements {@link org.apache.kafka.common.Configurable},
+ * the {@code configMap} will be passed to the {@code configure(Map<String, ?> configs)} method
+ * during initialization, allowing the credential provider to receive custom configuration parameters.
+ * </p>
+ *
+ * @see com.azure.core.credential.TokenCredential
+ * @see org.apache.kafka.common.Configurable
+ */
+public class CosmosCustomAuthConfig implements CosmosAuthConfig {
+    private final String credentialProviderClass;
+    private final Map<String, ?> configMap;
+
+    public CosmosCustomAuthConfig(String credentialProviderClass, Map<String, ?> configMap) {
+        this.credentialProviderClass = credentialProviderClass;
+        this.configMap = configMap;
+    }
+
+    public String getCredentialProviderClass() {
+        return credentialProviderClass;
+    }
+
+    public Map<String, ?> getConfigMap() {
+        return configMap;
+    }
+}

--- a/sdk/cosmos/azure-cosmos-kafka-connect/src/main/java/com/azure/cosmos/kafka/connect/implementation/KafkaCosmosConfig.java
+++ b/sdk/cosmos/azure-cosmos-kafka-connect/src/main/java/com/azure/cosmos/kafka/connect/implementation/KafkaCosmosConfig.java
@@ -1010,6 +1010,4 @@ public class KafkaCosmosConfig extends AbstractConfig {
             return "AzureEnvironment. Only allow " + CosmosAzureEnvironment.values();
         }
     }
-
-
 }

--- a/sdk/cosmos/azure-cosmos-kafka-connect/src/main/java/com/azure/cosmos/kafka/connect/implementation/KafkaCosmosConfig.java
+++ b/sdk/cosmos/azure-cosmos-kafka-connect/src/main/java/com/azure/cosmos/kafka/connect/implementation/KafkaCosmosConfig.java
@@ -3,7 +3,6 @@
 
 package com.azure.cosmos.kafka.connect.implementation;
 
-import com.azure.core.credential.TokenCredential;
 import com.azure.cosmos.implementation.Strings;
 import com.azure.cosmos.implementation.apachecommons.lang.StringUtils;
 import com.azure.cosmos.kafka.connect.implementation.sink.ItemWriteStrategy;
@@ -69,9 +68,7 @@ public class KafkaCosmosConfig extends AbstractConfig {
     private static final String AAD_CLIENT_SECRET_DISPLAY = "The client secret/password of the service principal.";
     private static final String DEFAULT_AAD_CLIENT_SECRET = Strings.Emtpy;
 
-    private static final String CREDENTIAL_PROVIDER_CLASS = "credential.provider.class";
-    private static final String CREDENTIAL_PROVIDER_CLASS_DOC = "Custom credential provider class name for authentication.";
-    private static final String CREDENTIAL_PROVIDER_CLASS_DISPLAY = "Credential provider class";
+    private static final String CREDENTIAL_PROVIDER_CLASS = "credentials.provider.class";
     private static final String DEFAULT_CREDENTIAL_PROVIDER_CLASS = Strings.Emtpy;
 
     private static final String AAD_AUTH_ENDPOINT_OVERRIDE = "azure.cosmos.auth.aad.authEndpointOverride";
@@ -451,16 +448,11 @@ public class KafkaCosmosConfig extends AbstractConfig {
                 ConfigDef.Width.LONG,
                 AAD_AUTH_ENDPOINT_OVERRIDE_DISPLAY
             )
-            .define(
+            .defineInternal(
                 CREDENTIAL_PROVIDER_CLASS,
                 ConfigDef.Type.STRING,
                 DEFAULT_CREDENTIAL_PROVIDER_CLASS,
-                ConfigDef.Importance.LOW,
-                CREDENTIAL_PROVIDER_CLASS_DOC,
-                accountGroupName,
-                accountGroupOrder++,
-                ConfigDef.Width.LONG,
-                CREDENTIAL_PROVIDER_CLASS_DISPLAY
+                ConfigDef.Importance.LOW
             )
             .define(
                 APPLICATION_NAME,

--- a/sdk/cosmos/azure-cosmos-kafka-connect/src/main/java/com/azure/cosmos/kafka/connect/implementation/KafkaCosmosConfig.java
+++ b/sdk/cosmos/azure-cosmos-kafka-connect/src/main/java/com/azure/cosmos/kafka/connect/implementation/KafkaCosmosConfig.java
@@ -3,6 +3,7 @@
 
 package com.azure.cosmos.kafka.connect.implementation;
 
+import com.azure.core.credential.TokenCredential;
 import com.azure.cosmos.implementation.Strings;
 import com.azure.cosmos.implementation.apachecommons.lang.StringUtils;
 import com.azure.cosmos.kafka.connect.implementation.sink.ItemWriteStrategy;
@@ -48,8 +49,8 @@ public class KafkaCosmosConfig extends AbstractConfig {
     private static final String DEFAULT_ACCOUNT_TENANT_ID = Strings.Emtpy;
 
     private static final String AUTH_TYPE = "azure.cosmos.auth.type";
-    private static final String AUTH_TYPE_DOC = "There are two auth types are supported currently: "
-        + "`MasterKey`(PrimaryReadWriteKeys, SecondReadWriteKeys, PrimaryReadOnlyKeys, SecondReadWriteKeys), `ServicePrincipal`";
+    private static final String AUTH_TYPE_DOC = "Authentication types supported: "
+        + "`MasterKey`(PrimaryReadWriteKeys, SecondReadWriteKeys, PrimaryReadOnlyKeys, SecondReadWriteKeys), `ServicePrincipal`, `Custom`";
     private static final String AUTH_TYPE_DISPLAY = "Cosmos Auth type.";
     private static final String DEFAULT_AUTH_TYPE = CosmosAuthType.MASTER_KEY.getName();
 
@@ -67,6 +68,11 @@ public class KafkaCosmosConfig extends AbstractConfig {
     private static final String AAD_CLIENT_SECRET_DOC = "The client secret/password of the service principal. Required for `ServicePrincipal` authentication.";
     private static final String AAD_CLIENT_SECRET_DISPLAY = "The client secret/password of the service principal.";
     private static final String DEFAULT_AAD_CLIENT_SECRET = Strings.Emtpy;
+
+    private static final String CREDENTIAL_PROVIDER_CLASS = "credential.provider.class";
+    private static final String CREDENTIAL_PROVIDER_CLASS_DOC = "Custom credential provider class name for authentication.";
+    private static final String CREDENTIAL_PROVIDER_CLASS_DISPLAY = "Credential provider class";
+    private static final String DEFAULT_CREDENTIAL_PROVIDER_CLASS = Strings.Emtpy;
 
     private static final String AAD_AUTH_ENDPOINT_OVERRIDE = "azure.cosmos.auth.aad.authEndpointOverride";
     private static final String AAD_AUTH_ENDPOINT_OVERRIDE_DOC = "Overrides the Azure Active Directory (AAD) authentication endpoint. "
@@ -198,9 +204,11 @@ public class KafkaCosmosConfig extends AbstractConfig {
 
     private final CosmosAccountConfig accountConfig;
     private final CosmosThroughputControlConfig throughputControlConfig;
+    private final Map<String, ?> rawConfigs;
 
     public KafkaCosmosConfig(ConfigDef config, Map<String, ?> parsedConfig) {
         super(config, parsedConfig);
+        this.rawConfigs = parsedConfig;
         this.accountConfig = this.parseAccountConfig();
         this.throughputControlConfig = this.parseThroughputControlConfig();
     }
@@ -268,6 +276,10 @@ public class KafkaCosmosConfig extends AbstractConfig {
                 return new CosmosMasterKeyAuthConfig(masterKey);
             case SERVICE_PRINCIPAL:
                 return new CosmosAadAuthConfig(clientId, clientSecret, authEndpointOverride, tenantId, azureEnvironment);
+            case CUSTOM:
+                return new CosmosCustomAuthConfig(
+                    this.getString(CREDENTIAL_PROVIDER_CLASS),
+                    this.rawConfigs);
             default:
                 throw new IllegalArgumentException("AuthType " + authType + " is not supported");
         }
@@ -439,6 +451,17 @@ public class KafkaCosmosConfig extends AbstractConfig {
                 accountGroupOrder++,
                 ConfigDef.Width.LONG,
                 AAD_AUTH_ENDPOINT_OVERRIDE_DISPLAY
+            )
+            .define(
+                CREDENTIAL_PROVIDER_CLASS,
+                ConfigDef.Type.STRING,
+                DEFAULT_CREDENTIAL_PROVIDER_CLASS,
+                ConfigDef.Importance.LOW,
+                CREDENTIAL_PROVIDER_CLASS_DOC,
+                accountGroupName,
+                accountGroupOrder++,
+                ConfigDef.Width.LONG,
+                CREDENTIAL_PROVIDER_CLASS_DISPLAY
             )
             .define(
                 APPLICATION_NAME,
@@ -762,7 +785,8 @@ public class KafkaCosmosConfig extends AbstractConfig {
                 THROUGHPUT_CONTROL_ACCOUNT_KEY,
                 THROUGHPUT_CONTROL_AAD_CLIENT_ID,
                 THROUGHPUT_CONTROL_AAD_CLIENT_SECRET,
-                AAD_AUTH_ENDPOINT_OVERRIDE);
+                AAD_AUTH_ENDPOINT_OVERRIDE,
+                CREDENTIAL_PROVIDER_CLASS);
         }
 
         // if throughput control is using aad auth, then only targetThroughput is supported
@@ -788,7 +812,8 @@ public class KafkaCosmosConfig extends AbstractConfig {
             ACCOUNT_KEY,
             AAD_CLIENT_ID,
             AAD_CLIENT_SECRET,
-            AAD_AUTH_ENDPOINT_OVERRIDE);
+            AAD_AUTH_ENDPOINT_OVERRIDE,
+            CREDENTIAL_PROVIDER_CLASS);
     }
 
     public static void validateAccountAuthConfigCore(
@@ -798,7 +823,8 @@ public class KafkaCosmosConfig extends AbstractConfig {
         String accountKeyConfig,
         String clientIdConfig,
         String clientSecretConfig,
-        String authEndpointOverrideConfig) {
+        String authEndpointOverrideConfig,
+        String providerClassConfig) {
 
         CosmosAuthType authType = CosmosAuthType.fromName(configValueMap.get(authTypeConfig).value().toString());
         switch (authType) {
@@ -843,6 +869,29 @@ public class KafkaCosmosConfig extends AbstractConfig {
                     }
                 }
 
+                break;
+            case CUSTOM:
+                String credentialProviderClassName = configValueMap.get(providerClassConfig).value().toString();
+                if(!StringUtils.isEmpty(credentialProviderClassName)) {
+                    try {
+                        Class<?> clazz = Class.forName(credentialProviderClassName);
+                        if (!TokenCredential.class.isAssignableFrom(clazz)) {
+                            configValueMap
+                                .get(providerClassConfig)
+                                .addErrorMessage("Custom auth type requires a valid credential provider class "
+                                    + "which implements TokenCredential interface");
+                        }
+                    } catch (ClassNotFoundException e) {
+                        configValueMap
+                            .get(providerClassConfig)
+                            .addErrorMessage("Could not find the credential provider class: " + credentialProviderClassName);
+                    }
+
+                } else {
+                    configValueMap
+                        .get(providerClassConfig)
+                        .addErrorMessage("Empty Credential provider class provided for CUSTOM auth type");
+                }
                 break;
             default:
                 throw new IllegalArgumentException("AuthType " + authType + " is not supported");

--- a/sdk/cosmos/azure-cosmos-kafka-connect/src/main/java/com/azure/cosmos/kafka/connect/implementation/KafkaCosmosConfig.java
+++ b/sdk/cosmos/azure-cosmos-kafka-connect/src/main/java/com/azure/cosmos/kafka/connect/implementation/KafkaCosmosConfig.java
@@ -277,9 +277,8 @@ public class KafkaCosmosConfig extends AbstractConfig {
             case SERVICE_PRINCIPAL:
                 return new CosmosAadAuthConfig(clientId, clientSecret, authEndpointOverride, tenantId, azureEnvironment);
             case CUSTOM:
-                return new CosmosCustomAuthConfig(
-                    this.getString(CREDENTIAL_PROVIDER_CLASS),
-                    this.rawConfigs);
+                String providerClassName = this.getString(CREDENTIAL_PROVIDER_CLASS);
+                return new CosmosCustomAuthConfig(providerClassName, this.rawConfigs);
             default:
                 throw new IllegalArgumentException("AuthType " + authType + " is not supported");
         }
@@ -871,26 +870,11 @@ public class KafkaCosmosConfig extends AbstractConfig {
 
                 break;
             case CUSTOM:
-                String credentialProviderClassName = configValueMap.get(providerClassConfig).value().toString();
-                if(!StringUtils.isEmpty(credentialProviderClassName)) {
-                    try {
-                        Class<?> clazz = Class.forName(credentialProviderClassName);
-                        if (!TokenCredential.class.isAssignableFrom(clazz)) {
-                            configValueMap
-                                .get(providerClassConfig)
-                                .addErrorMessage("Custom auth type requires a valid credential provider class "
-                                    + "which implements TokenCredential interface");
-                        }
-                    } catch (ClassNotFoundException e) {
-                        configValueMap
-                            .get(providerClassConfig)
-                            .addErrorMessage("Could not find the credential provider class: " + credentialProviderClassName);
-                    }
-
-                } else {
+                String providerClass = configValueMap.get(providerClassConfig).value().toString();
+                if (StringUtils.isEmpty(providerClass)) {
                     configValueMap
                         .get(providerClassConfig)
-                        .addErrorMessage("Empty Credential provider class provided for CUSTOM auth type");
+                        .addErrorMessage("Credential provider class is required for CUSTOM auth type");
                 }
                 break;
             default:
@@ -1026,4 +1010,6 @@ public class KafkaCosmosConfig extends AbstractConfig {
             return "AzureEnvironment. Only allow " + CosmosAzureEnvironment.values();
         }
     }
+
+
 }

--- a/sdk/cosmos/azure-cosmos-kafka-connect/src/test/java/com/azure/cosmos/kafka/connect/CosmosSinkConnectorTest.java
+++ b/sdk/cosmos/azure-cosmos-kafka-connect/src/test/java/com/azure/cosmos/kafka/connect/CosmosSinkConnectorTest.java
@@ -12,6 +12,8 @@ import com.azure.cosmos.implementation.TestConfigurations;
 import com.azure.cosmos.implementation.caches.AsyncCache;
 import com.azure.cosmos.kafka.connect.implementation.CosmosAadAuthConfig;
 import com.azure.cosmos.kafka.connect.implementation.CosmosAuthType;
+import com.azure.cosmos.kafka.connect.implementation.CosmosCustomAuthConfig;
+import com.azure.cosmos.kafka.connect.implementation.TestTokenCredential;
 import com.azure.cosmos.kafka.connect.implementation.KafkaCosmosUtils;
 import com.azure.cosmos.kafka.connect.implementation.sink.CosmosSinkConfig;
 import com.azure.cosmos.kafka.connect.implementation.sink.CosmosSinkTask;
@@ -412,6 +414,39 @@ public class CosmosSinkConnectorTest extends KafkaCosmosTestSuiteBase {
         return sinkConfigMap;
     }
 
+    @Test(groups = { "unit" })
+    public void sinkConfigWithCustomAuth() {
+        String credentialProviderClass = TestTokenCredential.class.getName();
+
+        Map<String, String> sinkConfigMap = this.getValidSinkConfig();
+        sinkConfigMap.put("azure.cosmos.auth.type", CosmosAuthType.CUSTOM.getName());
+        sinkConfigMap.put("credential.provider.class", credentialProviderClass);
+        sinkConfigMap.put("customProperty", "customValue");
+
+        CosmosSinkConfig sinkConfig = new CosmosSinkConfig(sinkConfigMap);
+        assertThat(sinkConfig.getAccountConfig()).isNotNull();
+        assertThat(sinkConfig.getAccountConfig().getCosmosAuthConfig()).isInstanceOf(CosmosCustomAuthConfig.class);
+        CosmosCustomAuthConfig cosmosCustomAuthConfig = (CosmosCustomAuthConfig) sinkConfig.getAccountConfig()
+                .getCosmosAuthConfig();
+        assertThat(cosmosCustomAuthConfig.getCredentialProviderClass()).isEqualTo(credentialProviderClass);
+        assertThat(cosmosCustomAuthConfig.getConfigMap().get("customProperty")).isEqualTo("customValue");
+    }
+
+    @Test(groups = { "unit" })
+    public void invalidCustomAuthConfigMissingCredentialProviderClass() {
+        CosmosSinkConnector sinkConnector = new CosmosSinkConnector();
+        Map<String, String> sinkConfigMap = this.getValidSinkConfig();
+        sinkConfigMap.put("azure.cosmos.auth.type", CosmosAuthType.CUSTOM.getName());
+        // Missing credential.provider.class
+
+        Config config = sinkConnector.validate(sinkConfigMap);
+        Map<String, List<String>> errorMessages = config.configValues().stream()
+            .collect(Collectors.toMap(ConfigValue::name, ConfigValue::errorMessages));
+        
+        // Should have error for missing credential provider class when using CUSTOM auth
+        assertThat(errorMessages.get("credential.provider.class").size()).isGreaterThan(0);
+    }
+
     public static class SinkConfigs {
         public static final List<KafkaCosmosConfigEntry<?>> ALL_VALID_CONFIGS = Arrays.asList(
             new KafkaCosmosConfigEntry<String>("azure.cosmos.account.endpoint", null, false),
@@ -421,6 +456,7 @@ public class CosmosSinkConnectorTest extends KafkaCosmosTestSuiteBase {
             new KafkaCosmosConfigEntry<String>("azure.cosmos.auth.aad.clientId", Strings.Emtpy, true),
             new KafkaCosmosConfigEntry<String>("azure.cosmos.auth.aad.clientSecret", Strings.Emtpy, true, true),
             new KafkaCosmosConfigEntry<String>("azure.cosmos.auth.aad.authEndpointOverride", Strings.Emtpy, true),
+            new KafkaCosmosConfigEntry<String>("credential.provider.class", Strings.Emtpy, true),
             new KafkaCosmosConfigEntry<Boolean>("azure.cosmos.mode.gateway", false, true),
             new KafkaCosmosConfigEntry<String>("azure.cosmos.preferredRegionList", Strings.Emtpy, true),
             new KafkaCosmosConfigEntry<String>("azure.cosmos.application.name", Strings.Emtpy, true),

--- a/sdk/cosmos/azure-cosmos-kafka-connect/src/test/java/com/azure/cosmos/kafka/connect/CosmosSourceConnectorTest.java
+++ b/sdk/cosmos/azure-cosmos-kafka-connect/src/test/java/com/azure/cosmos/kafka/connect/CosmosSourceConnectorTest.java
@@ -22,6 +22,8 @@ import com.azure.cosmos.implementation.feedranges.FeedRangeEpkImpl;
 import com.azure.cosmos.implementation.query.CompositeContinuationToken;
 import com.azure.cosmos.kafka.connect.implementation.CosmosAadAuthConfig;
 import com.azure.cosmos.kafka.connect.implementation.CosmosAuthType;
+import com.azure.cosmos.kafka.connect.implementation.CosmosCustomAuthConfig;
+import com.azure.cosmos.kafka.connect.implementation.TestTokenCredential;
 import com.azure.cosmos.kafka.connect.implementation.CosmosClientStore;
 import com.azure.cosmos.kafka.connect.implementation.KafkaCosmosUtils;
 import com.azure.cosmos.kafka.connect.implementation.source.CosmosChangeFeedMode;
@@ -1010,6 +1012,39 @@ public class CosmosSourceConnectorTest extends KafkaCosmosTestSuiteBase {
         }
     }
 
+    @Test(groups = { "unit" })
+    public void sourceConfigWithCustomAuth() {
+        String credentialProviderClass = TestTokenCredential.class.getName();
+
+        Map<String, String> sourceConfigMap = this.getValidSourceConfig();
+        sourceConfigMap.put("azure.cosmos.auth.type", CosmosAuthType.CUSTOM.getName());
+        sourceConfigMap.put("credential.provider.class", credentialProviderClass);
+        sourceConfigMap.put("customProperty", "customValue");
+
+        CosmosSourceConfig sourceConfig = new CosmosSourceConfig(sourceConfigMap);
+        assertThat(sourceConfig.getAccountConfig()).isNotNull();
+        assertThat(sourceConfig.getAccountConfig().getCosmosAuthConfig()).isInstanceOf(CosmosCustomAuthConfig.class);
+        CosmosCustomAuthConfig cosmosCustomAuthConfig = (CosmosCustomAuthConfig) sourceConfig.getAccountConfig()
+                .getCosmosAuthConfig();
+        assertThat(cosmosCustomAuthConfig.getCredentialProviderClass()).isEqualTo(credentialProviderClass);
+        assertThat(cosmosCustomAuthConfig.getConfigMap().get("customProperty")).isEqualTo("customValue");
+    }
+
+    @Test(groups = { "unit" })
+    public void invalidCustomAuthConfigMissingCredentialProviderClass() {
+        CosmosSourceConnector sourceConnector = new CosmosSourceConnector();
+        Map<String, String> sourceConfigMap = this.getValidSourceConfig();
+        sourceConfigMap.put("azure.cosmos.auth.type", CosmosAuthType.CUSTOM.getName());
+        // Missing credential.provider.class
+
+        Config config = sourceConnector.validate(sourceConfigMap);
+        Map<String, List<String>> errorMessages = config.configValues().stream()
+            .collect(Collectors.toMap(ConfigValue::name, ConfigValue::errorMessages));
+        
+        // Should have error for missing credential provider class when using CUSTOM auth
+        assertThat(errorMessages.get("credential.provider.class").size()).isGreaterThan(0);
+    }
+
     public static class SourceConfigs {
         public static final List<KafkaCosmosConfigEntry<?>> ALL_VALID_CONFIGS = Arrays.asList(
             new KafkaCosmosConfigEntry<String>("azure.cosmos.account.endpoint", null, false),
@@ -1019,6 +1054,7 @@ public class CosmosSourceConnectorTest extends KafkaCosmosTestSuiteBase {
             new KafkaCosmosConfigEntry<String>("azure.cosmos.auth.aad.clientId", Strings.Emtpy, true),
             new KafkaCosmosConfigEntry<String>("azure.cosmos.auth.aad.clientSecret", Strings.Emtpy, true, true),
             new KafkaCosmosConfigEntry<String>("azure.cosmos.auth.aad.authEndpointOverride", Strings.Emtpy, true),
+            new KafkaCosmosConfigEntry<String>("credential.provider.class", Strings.Emtpy, true),
             new KafkaCosmosConfigEntry<Boolean>("azure.cosmos.mode.gateway", false, true),
             new KafkaCosmosConfigEntry<String>("azure.cosmos.preferredRegionList", Strings.Emtpy, true),
             new KafkaCosmosConfigEntry<String>("azure.cosmos.application.name", Strings.Emtpy, true),

--- a/sdk/cosmos/azure-cosmos-kafka-connect/src/test/java/com/azure/cosmos/kafka/connect/implementation/ConfigurableTestTokenCredential.java
+++ b/sdk/cosmos/azure-cosmos-kafka-connect/src/test/java/com/azure/cosmos/kafka/connect/implementation/ConfigurableTestTokenCredential.java
@@ -1,0 +1,53 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.cosmos.kafka.connect.implementation;
+
+import com.azure.core.credential.AccessToken;
+import com.azure.core.credential.TokenCredential;
+import com.azure.core.credential.TokenRequestContext;
+import org.apache.kafka.common.Configurable;
+import reactor.core.publisher.Mono;
+
+import java.time.OffsetDateTime;
+import java.util.Map;
+
+/**
+ * Mock TokenCredential implementation that implements Configurable for testing custom authentication
+ */
+public class ConfigurableTestTokenCredential implements TokenCredential, Configurable {
+    private static final String DEFAULT_TOKEN = "configurable-test-token-67890";
+    
+    private String configuredToken = DEFAULT_TOKEN;
+    private OffsetDateTime expiresAt = OffsetDateTime.now().plusHours(1);
+    private Map<String, ?> configuration;
+    
+    public ConfigurableTestTokenCredential() {
+        // Default constructor required
+    }
+    
+    @Override
+    public void configure(Map<String, ?> configs) {
+        this.configuration = configs;
+        if (configs.containsKey("token")) {
+            this.configuredToken = configs.get("token").toString();
+        }
+        if (configs.containsKey("expiryMinutes")) {
+            int expiryMinutes = Integer.parseInt(configs.get("expiryMinutes").toString());
+            this.expiresAt = OffsetDateTime.now().plusMinutes(expiryMinutes);
+        }
+    }
+    
+    @Override
+    public Mono<AccessToken> getToken(TokenRequestContext request) {
+        return Mono.just(new AccessToken(configuredToken, expiresAt));
+    }
+    
+    public Map<String, ?> getConfiguration() {
+        return configuration;
+    }
+    
+    public String getConfiguredToken() {
+        return configuredToken;
+    }
+}

--- a/sdk/cosmos/azure-cosmos-kafka-connect/src/test/java/com/azure/cosmos/kafka/connect/implementation/CosmosClientStoreCustomAuthTest.java
+++ b/sdk/cosmos/azure-cosmos-kafka-connect/src/test/java/com/azure/cosmos/kafka/connect/implementation/CosmosClientStoreCustomAuthTest.java
@@ -1,0 +1,179 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.cosmos.kafka.connect.implementation;
+
+import com.azure.core.credential.AccessToken;
+import com.azure.core.credential.TokenCredential;
+import com.azure.core.credential.TokenRequestContext;
+import com.azure.cosmos.kafka.connect.KafkaCosmosReflectionUtils;
+import org.testng.annotations.Test;
+
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.testng.Assert.assertThrows;
+
+public class CosmosClientStoreCustomAuthTest {
+
+    @Test(groups = "unit")
+    public void testCreateCustomTokenCredentialWithValidClass() throws Exception {
+        // Arrange
+        String providerClassName = TestTokenCredential.class.getName();
+        Map<String, Object> configMap = new HashMap<>();
+        CosmosCustomAuthConfig customAuthConfig = new CosmosCustomAuthConfig(providerClassName, configMap);
+
+        // Act
+        TokenCredential credential = invokeCreateCustomTokenCredential(customAuthConfig);
+
+        // Assert
+        assertThat(credential).isNotNull();
+        assertThat(credential).isInstanceOf(TestTokenCredential.class);
+        
+        // Verify the credential works
+        TokenRequestContext context = new TokenRequestContext();
+        AccessToken token = credential.getToken(context).block();
+        assertThat(token).isNotNull();
+        assertThat(token.getToken()).isEqualTo("test-token-12345");
+    }
+
+    @Test(groups = "unit")
+    public void testCreateCustomTokenCredentialWithConfigurableClass() throws Exception {
+        // Arrange
+        String providerClassName = ConfigurableTestTokenCredential.class.getName();
+        Map<String, Object> configMap = new HashMap<>();
+        configMap.put("token", "custom-configured-token");
+        configMap.put("expiryMinutes", "30");
+        configMap.put("customProperty", "customValue");
+        
+        CosmosCustomAuthConfig customAuthConfig = new CosmosCustomAuthConfig(providerClassName, configMap);
+
+        // Act
+        TokenCredential credential = invokeCreateCustomTokenCredential(customAuthConfig);
+
+        // Assert
+        assertThat(credential).isNotNull();
+        assertThat(credential).isInstanceOf(ConfigurableTestTokenCredential.class);
+        
+        ConfigurableTestTokenCredential configurableCredential = (ConfigurableTestTokenCredential) credential;
+        assertThat(configurableCredential.getConfiguredToken()).isEqualTo("custom-configured-token");
+        assertThat(configurableCredential.getConfiguration()).isEqualTo(configMap);
+        
+        // Verify the credential works
+        TokenRequestContext context = new TokenRequestContext();
+        AccessToken token = credential.getToken(context).block();
+        assertThat(token).isNotNull();
+        assertThat(token.getToken()).isEqualTo("custom-configured-token");
+    }
+
+    @Test(groups = "unit")
+    public void testCreateCustomTokenCredentialWithNullClassName() {
+        // Arrange
+        Map<String, Object> configMap = new HashMap<>();
+        CosmosCustomAuthConfig customAuthConfig = new CosmosCustomAuthConfig(null, configMap);
+
+        // Act & Assert
+        verifyExceptionThrown(customAuthConfig, IllegalArgumentException.class, "Credential provider class is required for Custom authentication");
+    }
+
+    @Test(groups = "unit")
+    public void testCreateCustomTokenCredentialWithEmptyClassName() {
+        // Arrange
+        Map<String, Object> configMap = new HashMap<>();
+        CosmosCustomAuthConfig customAuthConfig = new CosmosCustomAuthConfig("", configMap);
+
+        // Act & Assert
+        verifyExceptionThrown(customAuthConfig, IllegalArgumentException.class, "Credential provider class is required for Custom authentication");
+    }
+
+    @Test(groups = "unit")
+    public void testCreateCustomTokenCredentialWithWhitespaceClassName() {
+        // Arrange
+        Map<String, Object> configMap = new HashMap<>();
+        CosmosCustomAuthConfig customAuthConfig = new CosmosCustomAuthConfig("   ", configMap);
+
+        // Act & Assert
+        verifyExceptionThrown(customAuthConfig, IllegalArgumentException.class, "Credential provider class is required for Custom authentication");
+    }
+
+    @Test(groups = "unit")
+    public void testCreateCustomTokenCredentialWithNonExistentClass() {
+        // Arrange
+        String nonExistentClassName = "com.nonexistent.FakeTokenCredential";
+        Map<String, Object> configMap = new HashMap<>();
+        CosmosCustomAuthConfig customAuthConfig = new CosmosCustomAuthConfig(nonExistentClassName, configMap);
+
+        // Act & Assert
+        verifyExceptionThrown(customAuthConfig, IllegalArgumentException.class, "startsWith:Credential provider class not found: " + nonExistentClassName);
+    }
+
+    @Test(groups = "unit")
+    public void testCreateCustomTokenCredentialWithClassThatDoesNotImplementTokenCredential() {
+        // Arrange
+        String invalidClassName = InvalidTestTokenCredential.class.getName();
+        Map<String, Object> configMap = new HashMap<>();
+        CosmosCustomAuthConfig customAuthConfig = new CosmosCustomAuthConfig(invalidClassName, configMap);
+
+        // Act & Assert
+        verifyExceptionThrown(customAuthConfig, IllegalArgumentException.class, "contains:cannot be cast to TokenCredential");
+    }
+
+    @Test(groups = "unit")
+    public void testCreateCustomTokenCredentialWithClassWithoutDefaultConstructor() {
+        // Arrange
+        String noDefaultConstructorClassName = NoDefaultConstructorTokenCredential.class.getName();
+        Map<String, Object> configMap = new HashMap<>();
+        CosmosCustomAuthConfig customAuthConfig = new CosmosCustomAuthConfig(noDefaultConstructorClassName, configMap);
+
+        // Act & Assert
+        verifyExceptionThrown(customAuthConfig, IllegalArgumentException.class, "startsWith:Credential provider class must have a public no-argument constructor: " + noDefaultConstructorClassName);
+    }
+
+    @Test(groups = "unit")
+    public void testCreateCustomTokenCredentialWithAbstractClass() {
+        // Arrange
+        String abstractClassName = "com.azure.core.credential.TokenCredential"; // This is an interface, but should trigger similar error
+        Map<String, Object> configMap = new HashMap<>();
+        CosmosCustomAuthConfig customAuthConfig = new CosmosCustomAuthConfig(abstractClassName, configMap);
+
+        // Act & Assert
+        verifyExceptionThrown(customAuthConfig, IllegalArgumentException.class, "contains:public no-argument constructor");
+    }
+
+    /**
+     * Helper method to invoke the private createCustomTokenCredential method using reflection
+     */
+    private TokenCredential invokeCreateCustomTokenCredential(CosmosCustomAuthConfig customAuthConfig) throws Exception {
+        Method method = CosmosClientStore.class.getDeclaredMethod("createCustomTokenCredential", CosmosCustomAuthConfig.class);
+        method.setAccessible(true);
+        return (TokenCredential) method.invoke(null, customAuthConfig);
+    }
+    
+    /**
+     * Helper method to verify that the correct exception is thrown, handling reflection wrappers
+     */
+    private void verifyExceptionThrown(CosmosCustomAuthConfig customAuthConfig, Class<? extends Exception> expectedExceptionClass, String expectedMessage) {
+        try {
+            invokeCreateCustomTokenCredential(customAuthConfig);
+            // Should not reach here
+            assertThat(false).as("Expected exception was not thrown").isTrue();
+        } catch (Exception e) {
+            Exception actualException = e;
+            if (e.getCause() instanceof Exception) {
+                actualException = (Exception) e.getCause();
+            }
+            assertThat(actualException).isInstanceOf(expectedExceptionClass);
+            if (expectedMessage != null) {
+                if (expectedMessage.startsWith("startsWith:")) {
+                    assertThat(actualException.getMessage()).startsWith(expectedMessage.substring(11));
+                } else if (expectedMessage.startsWith("contains:")) {
+                    assertThat(actualException.getMessage()).contains(expectedMessage.substring(9));
+                } else {
+                    assertThat(actualException.getMessage()).isEqualTo(expectedMessage);
+                }
+            }
+        }
+    }
+}

--- a/sdk/cosmos/azure-cosmos-kafka-connect/src/test/java/com/azure/cosmos/kafka/connect/implementation/CosmosCustomAuthConfigTest.java
+++ b/sdk/cosmos/azure-cosmos-kafka-connect/src/test/java/com/azure/cosmos/kafka/connect/implementation/CosmosCustomAuthConfigTest.java
@@ -1,0 +1,101 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.cosmos.kafka.connect.implementation;
+
+import org.testng.annotations.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+public class CosmosCustomAuthConfigTest {
+
+    @Test(groups = "unit")
+    public void testCosmosCustomAuthConfigCreation() {
+        // Arrange
+        String providerClassName = "com.example.TestTokenCredential";
+        Map<String, Object> configMap = new HashMap<>();
+        configMap.put("property1", "value1");
+        configMap.put("property2", 42);
+
+        // Act
+        CosmosCustomAuthConfig authConfig = new CosmosCustomAuthConfig(providerClassName, configMap);
+
+        // Assert
+        assertThat(authConfig.getCredentialProviderClass()).isEqualTo(providerClassName);
+        assertThat(authConfig.getConfigMap()).isEqualTo(configMap);
+        assertThat(authConfig.getConfigMap().get("property1")).isEqualTo("value1");
+        assertThat(authConfig.getConfigMap().get("property2")).isEqualTo(42);
+    }
+
+    @Test(groups = "unit")
+    public void testCosmosCustomAuthConfigWithNullClassName() {
+        // Arrange
+        Map<String, Object> configMap = new HashMap<>();
+        configMap.put("property1", "value1");
+
+        // Act
+        CosmosCustomAuthConfig authConfig = new CosmosCustomAuthConfig(null, configMap);
+
+        // Assert
+        assertThat(authConfig.getCredentialProviderClass()).isNull();
+        assertThat(authConfig.getConfigMap()).isEqualTo(configMap);
+    }
+
+    @Test(groups = "unit")
+    public void testCosmosCustomAuthConfigWithEmptyClassName() {
+        // Arrange
+        String emptyClassName = "";
+        Map<String, Object> configMap = new HashMap<>();
+
+        // Act
+        CosmosCustomAuthConfig authConfig = new CosmosCustomAuthConfig(emptyClassName, configMap);
+
+        // Assert
+        assertThat(authConfig.getCredentialProviderClass()).isEqualTo(emptyClassName);
+        assertThat(authConfig.getConfigMap()).isEqualTo(configMap);
+    }
+
+    @Test(groups = "unit")
+    public void testCosmosCustomAuthConfigWithNullConfigMap() {
+        // Arrange
+        String providerClassName = "com.example.TestTokenCredential";
+
+        // Act
+        CosmosCustomAuthConfig authConfig = new CosmosCustomAuthConfig(providerClassName, null);
+
+        // Assert
+        assertThat(authConfig.getCredentialProviderClass()).isEqualTo(providerClassName);
+        assertThat(authConfig.getConfigMap()).isNull();
+    }
+
+    @Test(groups = "unit")
+    public void testCosmosCustomAuthConfigWithEmptyConfigMap() {
+        // Arrange
+        String providerClassName = "com.example.TestTokenCredential";
+        Map<String, Object> emptyConfigMap = new HashMap<>();
+
+        // Act
+        CosmosCustomAuthConfig authConfig = new CosmosCustomAuthConfig(providerClassName, emptyConfigMap);
+
+        // Assert
+        assertThat(authConfig.getCredentialProviderClass()).isEqualTo(providerClassName);
+        assertThat(authConfig.getConfigMap()).isEqualTo(emptyConfigMap);
+        assertThat(authConfig.getConfigMap().isEmpty()).isTrue();
+    }
+
+    @Test(groups = "unit")
+    public void testCosmosCustomAuthConfigImplementsCosmosAuthConfig() {
+        // Arrange
+        String providerClassName = "com.example.TestTokenCredential";
+        Map<String, Object> configMap = new HashMap<>();
+
+        // Act
+        CosmosCustomAuthConfig authConfig = new CosmosCustomAuthConfig(providerClassName, configMap);
+
+        // Assert
+        assertThat(authConfig).isInstanceOf(CosmosAuthConfig.class);
+    }
+}

--- a/sdk/cosmos/azure-cosmos-kafka-connect/src/test/java/com/azure/cosmos/kafka/connect/implementation/CustomAuthErrorHandlingTest.java
+++ b/sdk/cosmos/azure-cosmos-kafka-connect/src/test/java/com/azure/cosmos/kafka/connect/implementation/CustomAuthErrorHandlingTest.java
@@ -1,0 +1,221 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.cosmos.kafka.connect.implementation;
+
+import com.azure.cosmos.implementation.TestConfigurations;
+import com.azure.cosmos.kafka.connect.CosmosSinkConnector;
+import com.azure.cosmos.kafka.connect.CosmosSourceConnector;
+import com.azure.cosmos.kafka.connect.KafkaCosmosReflectionUtils;
+import com.azure.cosmos.kafka.connect.KafkaCosmosTestSuiteBase;
+import com.azure.cosmos.kafka.connect.implementation.sink.CosmosSinkTask;
+import com.azure.cosmos.kafka.connect.implementation.source.CosmosSourceTask;
+import org.apache.kafka.common.config.Config;
+import org.apache.kafka.connect.sink.SinkTaskContext;
+import org.mockito.Mockito;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.testng.Assert.assertThrows;
+
+public class CustomAuthErrorHandlingTest extends KafkaCosmosTestSuiteBase {
+
+    @Test(groups = { "unit" })
+    public void sinkTaskFailsWithInvalidCredentialProviderClass() {
+        String topicName = singlePartitionContainerName;
+
+        Map<String, String> sinkConfigMap = new HashMap<>();
+        sinkConfigMap.put("azure.cosmos.account.endpoint", TestConfigurations.HOST);
+        sinkConfigMap.put("azure.cosmos.auth.type", CosmosAuthType.CUSTOM.getName());
+        sinkConfigMap.put("credential.provider.class", InvalidTestTokenCredential.class.getName());
+        sinkConfigMap.put("azure.cosmos.sink.database.name", databaseName);
+        sinkConfigMap.put("azure.cosmos.sink.containers.topicMap", topicName + "#" + singlePartitionContainerName);
+        sinkConfigMap.put("azure.cosmos.sink.task.id", UUID.randomUUID().toString());
+
+        CosmosSinkTask sinkTask = new CosmosSinkTask();
+        SinkTaskContext sinkTaskContext = Mockito.mock(SinkTaskContext.class);
+        Mockito.when(sinkTaskContext.errantRecordReporter()).thenReturn(null);
+        KafkaCosmosReflectionUtils.setSinkTaskContext(sinkTask, sinkTaskContext);
+
+        // Should throw IllegalArgumentException when trying to start with invalid credential provider
+        try {
+            sinkTask.start(sinkConfigMap);
+            // Should not reach here
+            assertThat(false).isTrue();
+        } catch (IllegalArgumentException exception) {
+            assertThat(exception.getMessage()).contains("cannot be cast to TokenCredential");
+            assertThat(exception.getMessage()).contains("doesn't implement TokenCredential interface");
+        }
+    }
+
+    @Test(groups = { "unit" })
+    public void sinkTaskFailsWithNonExistentCredentialProviderClass() {
+        String topicName = singlePartitionContainerName;
+
+        Map<String, String> sinkConfigMap = new HashMap<>();
+        sinkConfigMap.put("azure.cosmos.account.endpoint", TestConfigurations.HOST);
+        sinkConfigMap.put("azure.cosmos.auth.type", CosmosAuthType.CUSTOM.getName());
+        sinkConfigMap.put("credential.provider.class", "com.nonexistent.FakeTokenCredential");
+        sinkConfigMap.put("azure.cosmos.sink.database.name", databaseName);
+        sinkConfigMap.put("azure.cosmos.sink.containers.topicMap", topicName + "#" + singlePartitionContainerName);
+        sinkConfigMap.put("azure.cosmos.sink.task.id", UUID.randomUUID().toString());
+
+        CosmosSinkTask sinkTask = new CosmosSinkTask();
+        SinkTaskContext sinkTaskContext = Mockito.mock(SinkTaskContext.class);
+        Mockito.when(sinkTaskContext.errantRecordReporter()).thenReturn(null);
+        KafkaCosmosReflectionUtils.setSinkTaskContext(sinkTask, sinkTaskContext);
+
+        // Should throw IllegalArgumentException when trying to start with non-existent credential provider
+        try {
+            sinkTask.start(sinkConfigMap);
+            // Should not reach here
+            assertThat(false).isTrue();
+        } catch (IllegalArgumentException exception) {
+            assertThat(exception.getMessage()).startsWith("Credential provider class not found:");
+            assertThat(exception.getCause()).isInstanceOf(ClassNotFoundException.class);
+        }
+    }
+
+    @Test(groups = { "unit" })
+    public void sinkTaskFailsWithCredentialProviderWithoutDefaultConstructor() {
+        String topicName = singlePartitionContainerName;
+
+        Map<String, String> sinkConfigMap = new HashMap<>();
+        sinkConfigMap.put("azure.cosmos.account.endpoint", TestConfigurations.HOST);
+        sinkConfigMap.put("azure.cosmos.auth.type", CosmosAuthType.CUSTOM.getName());
+        sinkConfigMap.put("credential.provider.class", NoDefaultConstructorTokenCredential.class.getName());
+        sinkConfigMap.put("azure.cosmos.sink.database.name", databaseName);
+        sinkConfigMap.put("azure.cosmos.sink.containers.topicMap", topicName + "#" + singlePartitionContainerName);
+        sinkConfigMap.put("azure.cosmos.sink.task.id", UUID.randomUUID().toString());
+
+        CosmosSinkTask sinkTask = new CosmosSinkTask();
+        SinkTaskContext sinkTaskContext = Mockito.mock(SinkTaskContext.class);
+        Mockito.when(sinkTaskContext.errantRecordReporter()).thenReturn(null);
+        KafkaCosmosReflectionUtils.setSinkTaskContext(sinkTask, sinkTaskContext);
+
+        // Should throw IllegalArgumentException when trying to start with credential provider without default constructor
+        try {
+            sinkTask.start(sinkConfigMap);
+            // Should not reach here
+            assertThat(false).isTrue();
+        } catch (IllegalArgumentException exception) {
+            assertThat(exception.getMessage()).contains("must have a public no-argument constructor");
+            assertThat(exception.getCause()).isInstanceOf(NoSuchMethodException.class);
+        }
+    }
+
+    @Test(groups = { "unit" })
+    public void sinkTaskFailsWithEmptyCredentialProviderClass() {
+        String topicName = singlePartitionContainerName;
+
+        Map<String, String> sinkConfigMap = new HashMap<>();
+        sinkConfigMap.put("azure.cosmos.account.endpoint", TestConfigurations.HOST);
+        sinkConfigMap.put("azure.cosmos.auth.type", CosmosAuthType.CUSTOM.getName());
+        sinkConfigMap.put("credential.provider.class", ""); // Empty class name
+        sinkConfigMap.put("azure.cosmos.sink.database.name", databaseName);
+        sinkConfigMap.put("azure.cosmos.sink.containers.topicMap", topicName + "#" + singlePartitionContainerName);
+        sinkConfigMap.put("azure.cosmos.sink.task.id", UUID.randomUUID().toString());
+
+        CosmosSinkTask sinkTask = new CosmosSinkTask();
+        SinkTaskContext sinkTaskContext = Mockito.mock(SinkTaskContext.class);
+        Mockito.when(sinkTaskContext.errantRecordReporter()).thenReturn(null);
+        KafkaCosmosReflectionUtils.setSinkTaskContext(sinkTask, sinkTaskContext);
+
+        // Should throw IllegalArgumentException when trying to start with empty credential provider class
+        try {
+            sinkTask.start(sinkConfigMap);
+            // Should not reach here
+            assertThat(false).isTrue();
+        } catch (IllegalArgumentException exception) {
+            assertThat(exception.getMessage()).isEqualTo("Credential provider class is required for Custom authentication");
+        }
+    }
+
+    @Test(groups = { "unit" })
+    public void sourceTaskFailsWithInvalidCredentialProviderClass() {
+        Map<String, String> sourceConfigMap = new HashMap<>();
+        sourceConfigMap.put("azure.cosmos.account.endpoint", TestConfigurations.HOST);
+        sourceConfigMap.put("azure.cosmos.auth.type", CosmosAuthType.CUSTOM.getName());
+        sourceConfigMap.put("credential.provider.class", InvalidTestTokenCredential.class.getName());
+        sourceConfigMap.put("azure.cosmos.source.database.name", databaseName);
+        sourceConfigMap.put("azure.cosmos.source.containers.includedList", Arrays.asList(singlePartitionContainerName).toString());
+        sourceConfigMap.put("azure.cosmos.source.task.id", UUID.randomUUID().toString());
+        sourceConfigMap.put("azure.cosmos.source.task.feedRangeTaskUnits", "[]"); // Empty but valid JSON array
+
+        CosmosSourceTask sourceTask = new CosmosSourceTask();
+
+        // Should throw IllegalArgumentException when trying to start with invalid credential provider
+        try {
+            sourceTask.start(sourceConfigMap);
+            // Should not reach here
+            assertThat(false).isTrue();
+        } catch (IllegalArgumentException exception) {
+            assertThat(exception.getMessage()).contains("cannot be cast to TokenCredential");
+        }
+    }
+
+    @Test(groups = { "unit" })
+    public void sourceTaskFailsWithNonExistentCredentialProviderClass() {
+        Map<String, String> sourceConfigMap = new HashMap<>();
+        sourceConfigMap.put("azure.cosmos.account.endpoint", TestConfigurations.HOST);
+        sourceConfigMap.put("azure.cosmos.auth.type", CosmosAuthType.CUSTOM.getName());
+        sourceConfigMap.put("credential.provider.class", "com.nonexistent.FakeTokenCredential");
+        sourceConfigMap.put("azure.cosmos.source.database.name", databaseName);
+        sourceConfigMap.put("azure.cosmos.source.containers.includedList", Arrays.asList(singlePartitionContainerName).toString());
+        sourceConfigMap.put("azure.cosmos.source.task.id", UUID.randomUUID().toString());
+        sourceConfigMap.put("azure.cosmos.source.task.feedRangeTaskUnits", "[]"); // Empty but valid JSON array
+
+        CosmosSourceTask sourceTask = new CosmosSourceTask();
+
+        // Should throw IllegalArgumentException when trying to start with non-existent credential provider
+        try {
+            sourceTask.start(sourceConfigMap);
+            // Should not reach here
+            assertThat(false).isTrue();
+        } catch (IllegalArgumentException exception) {
+            assertThat(exception.getMessage()).startsWith("Credential provider class not found:");
+            assertThat(exception.getCause()).isInstanceOf(ClassNotFoundException.class);
+        }
+    }
+
+    @Test(groups = { "unit" })
+    public void connectorValidationFailsForCustomAuthWithoutCredentialProvider() {
+        CosmosSinkConnector sinkConnector = new CosmosSinkConnector();
+        
+        Map<String, String> sinkConfigMap = new HashMap<>();
+        sinkConfigMap.put("azure.cosmos.account.endpoint", TestConfigurations.HOST);
+        sinkConfigMap.put("azure.cosmos.auth.type", CosmosAuthType.CUSTOM.getName());
+        // Missing credential.provider.class
+        sinkConfigMap.put("azure.cosmos.sink.database.name", "testDatabase");
+        sinkConfigMap.put("azure.cosmos.sink.containers.topicMap", "topic#container");
+
+        Config config = sinkConnector.validate(sinkConfigMap);
+        boolean hasErrors = config.configValues().stream()
+            .anyMatch(configValue -> !configValue.errorMessages().isEmpty());
+            
+        assertThat(hasErrors).isTrue();
+    }
+
+    @Test(groups = { "unit" })
+    public void sourceConnectorValidationFailsForCustomAuthWithoutCredentialProvider() {
+        CosmosSourceConnector sourceConnector = new CosmosSourceConnector();
+        
+        Map<String, String> sourceConfigMap = new HashMap<>();
+        sourceConfigMap.put("azure.cosmos.account.endpoint", TestConfigurations.HOST);
+        sourceConfigMap.put("azure.cosmos.auth.type", CosmosAuthType.CUSTOM.getName());
+        // Missing credential.provider.class
+        sourceConfigMap.put("azure.cosmos.source.database.name", "testDatabase");
+        sourceConfigMap.put("azure.cosmos.source.containers.includedList", Arrays.asList("container1").toString());
+
+        Config config = sourceConnector.validate(sourceConfigMap);
+        boolean hasErrors = config.configValues().stream()
+            .anyMatch(configValue -> !configValue.errorMessages().isEmpty());
+            
+        assertThat(hasErrors).isTrue();
+    }
+}

--- a/sdk/cosmos/azure-cosmos-kafka-connect/src/test/java/com/azure/cosmos/kafka/connect/implementation/CustomAuthIntegrationTest.java
+++ b/sdk/cosmos/azure-cosmos-kafka-connect/src/test/java/com/azure/cosmos/kafka/connect/implementation/CustomAuthIntegrationTest.java
@@ -1,0 +1,250 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.cosmos.kafka.connect.implementation;
+
+import com.azure.cosmos.CosmosAsyncClient;
+import com.azure.cosmos.CosmosAsyncContainer;
+import com.azure.cosmos.implementation.TestConfigurations;
+import com.azure.cosmos.implementation.Utils;
+import com.azure.cosmos.kafka.connect.CosmosSinkConnector;
+import com.azure.cosmos.kafka.connect.CosmosSourceConnector;
+import com.azure.cosmos.kafka.connect.KafkaCosmosReflectionUtils;
+import com.azure.cosmos.kafka.connect.KafkaCosmosTestConfigurations;
+import com.azure.cosmos.kafka.connect.KafkaCosmosTestSuiteBase;
+import com.azure.cosmos.kafka.connect.TestItem;
+import com.azure.cosmos.kafka.connect.implementation.sink.CosmosSinkTask;
+import com.azure.cosmos.kafka.connect.implementation.source.CosmosSourceTask;
+import com.azure.cosmos.models.CosmosContainerProperties;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.apache.kafka.common.config.Config;
+import org.apache.kafka.connect.data.ConnectSchema;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.apache.kafka.connect.sink.SinkTaskContext;
+import org.mockito.Mockito;
+import org.testng.annotations.Test;
+import reactor.core.publisher.Mono;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+public class CustomAuthIntegrationTest extends KafkaCosmosTestSuiteBase {
+
+    @Test(groups = { "kafka", "kafka-emulator" }, timeOut = TIMEOUT)
+    public void sinkTaskWithCustomAuthentication() {
+        String topicName = singlePartitionContainerName;
+
+        Map<String, String> sinkConfigMap = new HashMap<>();
+        sinkConfigMap.put("azure.cosmos.account.endpoint", TestConfigurations.HOST);
+        // Use CUSTOM auth type with our test credential provider
+        sinkConfigMap.put("azure.cosmos.auth.type", CosmosAuthType.CUSTOM.getName());
+        sinkConfigMap.put("credential.provider.class", TestTokenCredential.class.getName());
+        sinkConfigMap.put("azure.cosmos.sink.database.name", databaseName);
+        sinkConfigMap.put("azure.cosmos.sink.containers.topicMap", topicName + "#" + singlePartitionContainerName);
+        sinkConfigMap.put("azure.cosmos.sink.bulk.enabled", "true");
+        sinkConfigMap.put("azure.cosmos.sink.task.id", UUID.randomUUID().toString());
+
+        CosmosSinkTask sinkTask = new CosmosSinkTask();
+        SinkTaskContext sinkTaskContext = Mockito.mock(SinkTaskContext.class);
+        Mockito.when(sinkTaskContext.errantRecordReporter()).thenReturn(null);
+        KafkaCosmosReflectionUtils.setSinkTaskContext(sinkTask, sinkTaskContext);
+
+        try {
+            sinkTask.start(sinkConfigMap);
+
+            CosmosAsyncClient cosmosClient = KafkaCosmosReflectionUtils.getSinkTaskCosmosClient(sinkTask);
+            CosmosContainerProperties singlePartitionContainerProperties = getSinglePartitionContainer(cosmosClient);
+            CosmosAsyncContainer container = cosmosClient.getDatabase(databaseName).getContainer(singlePartitionContainerProperties.getId());
+
+            List<SinkRecord> sinkRecordList = new ArrayList<>();
+            List<TestItem> toBeCreateItems = new ArrayList<>();
+            
+            // Create test records
+            for (int i = 0; i < 5; i++) {
+                TestItem testItem = TestItem.createNewItem();
+                toBeCreateItems.add(testItem);
+
+                SinkRecord sinkRecord = new SinkRecord(
+                    topicName,
+                    1,
+                    new ConnectSchema(Schema.Type.STRING),
+                    testItem.getId(),
+                    new ConnectSchema(Schema.Type.MAP),
+                    Utils.getSimpleObjectMapper().convertValue(
+                        Utils.getSimpleObjectMapper().convertValue(testItem, ObjectNode.class), 
+                        new TypeReference<Map<String, Object>>() {}),
+                    0L);
+                sinkRecordList.add(sinkRecord);
+            }
+
+            sinkTask.put(sinkRecordList);
+
+            // Verify items were written
+            List<String> writtenItemIds = new ArrayList<>();
+            String query = "select * from c";
+            container.queryItems(query, TestItem.class)
+                .byPage()
+                .flatMap(response -> {
+                    writtenItemIds.addAll(
+                        response.getResults().stream().map(TestItem::getId).collect(Collectors.toList()));
+                    return Mono.empty();
+                })
+                .blockLast();
+
+            assertThat(writtenItemIds.size()).isEqualTo(toBeCreateItems.size());
+            List<String> toBeCreateItemIds = toBeCreateItems.stream().map(TestItem::getId).collect(Collectors.toList());
+            assertThat(writtenItemIds.containsAll(toBeCreateItemIds)).isTrue();
+
+        } finally {
+            sinkTask.stop();
+        }
+    }
+
+    @Test(groups = { "kafka", "kafka-emulator" }, timeOut = TIMEOUT)
+    public void sinkTaskWithConfigurableCustomAuthentication() {
+        String topicName = singlePartitionContainerName;
+
+        Map<String, String> sinkConfigMap = new HashMap<>();
+        sinkConfigMap.put("azure.cosmos.account.endpoint", TestConfigurations.HOST);
+        // Use CUSTOM auth type with configurable test credential provider
+        sinkConfigMap.put("azure.cosmos.auth.type", CosmosAuthType.CUSTOM.getName());
+        sinkConfigMap.put("credential.provider.class", ConfigurableTestTokenCredential.class.getName());
+        sinkConfigMap.put("token", "custom-integration-token");
+        sinkConfigMap.put("expiryMinutes", "60");
+        sinkConfigMap.put("azure.cosmos.sink.database.name", databaseName);
+        sinkConfigMap.put("azure.cosmos.sink.containers.topicMap", topicName + "#" + singlePartitionContainerName);
+        sinkConfigMap.put("azure.cosmos.sink.bulk.enabled", "false");
+        sinkConfigMap.put("azure.cosmos.sink.task.id", UUID.randomUUID().toString());
+
+        CosmosSinkTask sinkTask = new CosmosSinkTask();
+        SinkTaskContext sinkTaskContext = Mockito.mock(SinkTaskContext.class);
+        Mockito.when(sinkTaskContext.errantRecordReporter()).thenReturn(null);
+        KafkaCosmosReflectionUtils.setSinkTaskContext(sinkTask, sinkTaskContext);
+
+        try {
+            sinkTask.start(sinkConfigMap);
+
+            CosmosAsyncClient cosmosClient = KafkaCosmosReflectionUtils.getSinkTaskCosmosClient(sinkTask);
+            CosmosContainerProperties singlePartitionContainerProperties = getSinglePartitionContainer(cosmosClient);
+            CosmosAsyncContainer container = cosmosClient.getDatabase(databaseName).getContainer(singlePartitionContainerProperties.getId());
+
+            List<SinkRecord> sinkRecordList = new ArrayList<>();
+            List<TestItem> toBeCreateItems = new ArrayList<>();
+            
+            // Create test records
+            for (int i = 0; i < 3; i++) {
+                TestItem testItem = TestItem.createNewItem();
+                toBeCreateItems.add(testItem);
+
+                SinkRecord sinkRecord = new SinkRecord(
+                    topicName,
+                    1,
+                    new ConnectSchema(Schema.Type.STRING),
+                    testItem.getId(),
+                    new ConnectSchema(Schema.Type.MAP),
+                    Utils.getSimpleObjectMapper().convertValue(
+                        Utils.getSimpleObjectMapper().convertValue(testItem, ObjectNode.class), 
+                        new TypeReference<Map<String, Object>>() {}),
+                    0L);
+                sinkRecordList.add(sinkRecord);
+            }
+
+            sinkTask.put(sinkRecordList);
+
+            // Verify items were written
+            List<String> writtenItemIds = new ArrayList<>();
+            String query = "select * from c";
+            container.queryItems(query, TestItem.class)
+                .byPage()
+                .flatMap(response -> {
+                    writtenItemIds.addAll(
+                        response.getResults().stream().map(TestItem::getId).collect(Collectors.toList()));
+                    return Mono.empty();
+                })
+                .blockLast();
+
+            assertThat(writtenItemIds.size()).isEqualTo(toBeCreateItems.size());
+            List<String> toBeCreateItemIds = toBeCreateItems.stream().map(TestItem::getId).collect(Collectors.toList());
+            assertThat(writtenItemIds.containsAll(toBeCreateItemIds)).isTrue();
+
+        } finally {
+            sinkTask.stop();
+        }
+    }
+
+    @Test(groups = { "kafka", "kafka-emulator" }, timeOut = TIMEOUT)
+    public void sourceTaskWithCustomAuthentication() {
+        Map<String, String> sourceConfigMap = new HashMap<>();
+        sourceConfigMap.put("azure.cosmos.account.endpoint", KafkaCosmosTestConfigurations.HOST);
+        // Use CUSTOM auth type with our test credential provider
+        sourceConfigMap.put("azure.cosmos.auth.type", CosmosAuthType.CUSTOM.getName());
+        sourceConfigMap.put("credential.provider.class", TestTokenCredential.class.getName());
+        sourceConfigMap.put("azure.cosmos.source.database.name", databaseName);
+        sourceConfigMap.put("azure.cosmos.source.containers.includedList", Arrays.asList(singlePartitionContainerName).toString());
+        sourceConfigMap.put("azure.cosmos.source.task.id", UUID.randomUUID().toString());
+        sourceConfigMap.put("azure.cosmos.source.task.feedRangeTaskUnits", "[]"); // Empty but valid JSON array
+
+        CosmosSourceTask sourceTask = new CosmosSourceTask();
+
+        try {
+            sourceTask.start(sourceConfigMap);
+
+            // Verify that the task started successfully with custom authentication
+            // The fact that it doesn't throw an exception indicates success
+            assertThat(sourceTask).isNotNull();
+
+        } finally {
+            sourceTask.stop();
+        }
+    }
+
+    @Test(groups = { "unit" })
+    public void sinkConnectorValidatesCustomAuthConfig() {
+        CosmosSinkConnector sinkConnector = new CosmosSinkConnector();
+        
+        Map<String, String> sinkConfigMap = new HashMap<>();
+        sinkConfigMap.put("azure.cosmos.account.endpoint", KafkaCosmosTestConfigurations.HOST);
+        sinkConfigMap.put("azure.cosmos.auth.type", CosmosAuthType.CUSTOM.getName());
+        sinkConfigMap.put("credential.provider.class", TestTokenCredential.class.getName());
+        sinkConfigMap.put("azure.cosmos.sink.database.name", "testDatabase");
+        sinkConfigMap.put("azure.cosmos.sink.containers.topicMap", "topic#container");
+        sinkConfigMap.put("customProperty", "customValue");
+
+        // This should not throw any validation errors
+        Config config = sinkConnector.validate(sinkConfigMap);
+        boolean hasErrors = config.configValues().stream()
+            .anyMatch(configValue -> !configValue.errorMessages().isEmpty());
+            
+        assertThat(hasErrors).isFalse();
+    }
+
+    @Test(groups = { "unit" })
+    public void sourceConnectorValidatesCustomAuthConfig() {
+        CosmosSourceConnector sourceConnector = new CosmosSourceConnector();
+        
+        Map<String, String> sourceConfigMap = new HashMap<>();
+        sourceConfigMap.put("azure.cosmos.account.endpoint", KafkaCosmosTestConfigurations.HOST);
+        sourceConfigMap.put("azure.cosmos.auth.type", CosmosAuthType.CUSTOM.getName());
+        sourceConfigMap.put("credential.provider.class", ConfigurableTestTokenCredential.class.getName());
+        sourceConfigMap.put("azure.cosmos.source.database.name", "testDatabase");
+        sourceConfigMap.put("azure.cosmos.source.containers.includedList", Arrays.asList("container1").toString());
+        sourceConfigMap.put("token", "custom-token");
+        sourceConfigMap.put("expiryMinutes", "45");
+
+        // This should not throw any validation errors
+        Config config = sourceConnector.validate(sourceConfigMap);
+        boolean hasErrors = config.configValues().stream()
+            .anyMatch(configValue -> !configValue.errorMessages().isEmpty());
+            
+        assertThat(hasErrors).isFalse();
+    }
+}

--- a/sdk/cosmos/azure-cosmos-kafka-connect/src/test/java/com/azure/cosmos/kafka/connect/implementation/InvalidTestTokenCredential.java
+++ b/sdk/cosmos/azure-cosmos-kafka-connect/src/test/java/com/azure/cosmos/kafka/connect/implementation/InvalidTestTokenCredential.java
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.cosmos.kafka.connect.implementation;
+
+/**
+ * Mock class that does NOT implement TokenCredential for testing error scenarios
+ */
+public class InvalidTestTokenCredential {
+    
+    public InvalidTestTokenCredential() {
+        // Default constructor
+    }
+    
+    public String getInvalidMethod() {
+        return "This class does not implement TokenCredential";
+    }
+}

--- a/sdk/cosmos/azure-cosmos-kafka-connect/src/test/java/com/azure/cosmos/kafka/connect/implementation/NoDefaultConstructorTokenCredential.java
+++ b/sdk/cosmos/azure-cosmos-kafka-connect/src/test/java/com/azure/cosmos/kafka/connect/implementation/NoDefaultConstructorTokenCredential.java
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.cosmos.kafka.connect.implementation;
+
+import com.azure.core.credential.AccessToken;
+import com.azure.core.credential.TokenCredential;
+import com.azure.core.credential.TokenRequestContext;
+import reactor.core.publisher.Mono;
+
+import java.time.OffsetDateTime;
+
+/**
+ * Mock TokenCredential implementation without default constructor for testing error scenarios
+ */
+public class NoDefaultConstructorTokenCredential implements TokenCredential {
+    
+    private final String requiredParameter;
+    
+    // Only parameterized constructor - no default constructor
+    public NoDefaultConstructorTokenCredential(String requiredParameter) {
+        this.requiredParameter = requiredParameter;
+    }
+    
+    @Override
+    public Mono<AccessToken> getToken(TokenRequestContext request) {
+        return Mono.just(new AccessToken("no-default-constructor-token", OffsetDateTime.now().plusHours(1)));
+    }
+}

--- a/sdk/cosmos/azure-cosmos-kafka-connect/src/test/java/com/azure/cosmos/kafka/connect/implementation/TestTokenCredential.java
+++ b/sdk/cosmos/azure-cosmos-kafka-connect/src/test/java/com/azure/cosmos/kafka/connect/implementation/TestTokenCredential.java
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.cosmos.kafka.connect.implementation;
+
+import com.azure.core.credential.AccessToken;
+import com.azure.core.credential.TokenCredential;
+import com.azure.core.credential.TokenRequestContext;
+import reactor.core.publisher.Mono;
+
+import java.time.OffsetDateTime;
+
+/**
+ * Mock TokenCredential implementation for testing custom authentication
+ */
+public class TestTokenCredential implements TokenCredential {
+    private static final String DEFAULT_TOKEN = "test-token-12345";
+    private static final OffsetDateTime DEFAULT_EXPIRY = OffsetDateTime.now().plusHours(1);
+    
+    private final String token;
+    private final OffsetDateTime expiresAt;
+    
+    public TestTokenCredential() {
+        this(DEFAULT_TOKEN, DEFAULT_EXPIRY);
+    }
+    
+    public TestTokenCredential(String token, OffsetDateTime expiresAt) {
+        this.token = token;
+        this.expiresAt = expiresAt;
+    }
+    
+    @Override
+    public Mono<AccessToken> getToken(TokenRequestContext request) {
+        return Mono.just(new AccessToken(token, expiresAt));
+    }
+}


### PR DESCRIPTION
# Description
This pull request adds support for custom authentication in Azure Cosmos DB Kafka Connect by allowing users to specify their own credential provider class. The main changes include introducing a new `Custom` authentication type, updating configuration and validation logic, and implementing dynamic loading of custom credential providers.

### Custom Authentication Support

* Added `CUSTOM` as a new authentication type in the `CosmosAuthType` enum, allowing users to select custom authentication.
* Introduced the `CosmosCustomAuthConfig` class to encapsulate configuration for custom credential providers, including the provider class name and configuration map.
* Updated `KafkaCosmosConfig` to support the new `Custom` auth type, including new configuration keys (`credential.provider.class`), documentation, parsing logic, and validation to ensure the provider class is specified. [[1]](diffhunk://#diff-1b81f4e8e862f02e9ed174d88de1f50ea52024e819f697191c111676955b168dL51-R53) [[2]](diffhunk://#diff-1b81f4e8e862f02e9ed174d88de1f50ea52024e819f697191c111676955b168dR72-R76) [[3]](diffhunk://#diff-1b81f4e8e862f02e9ed174d88de1f50ea52024e819f697191c111676955b168dR207-R211) [[4]](diffhunk://#diff-1b81f4e8e862f02e9ed174d88de1f50ea52024e819f697191c111676955b168dR279-R281) [[5]](diffhunk://#diff-1b81f4e8e862f02e9ed174d88de1f50ea52024e819f697191c111676955b168dR454-R464) [[6]](diffhunk://#diff-1b81f4e8e862f02e9ed174d88de1f50ea52024e819f697191c111676955b168dL765-R788) [[7]](diffhunk://#diff-1b81f4e8e862f02e9ed174d88de1f50ea52024e819f697191c111676955b168dL791-R815) [[8]](diffhunk://#diff-1b81f4e8e862f02e9ed174d88de1f50ea52024e819f697191c111676955b168dL801-R826) [[9]](diffhunk://#diff-1b81f4e8e862f02e9ed174d88de1f50ea52024e819f697191c111676955b168dR871-R878)

### Dynamic Credential Provider Loading

* In `CosmosClientStore`, implemented logic to dynamically load and instantiate a custom credential provider class using reflection. The class must implement `TokenCredential` and can optionally implement `Configurable` for configuration injection. Comprehensive error handling is included for missing, invalid, or misconfigured classes. [[1]](diffhunk://#diff-735aaa86864f9c1242436f945e048e86a9d6707f057faa65e308c75252bd2c12R59-R62) [[2]](diffhunk://#diff-735aaa86864f9c1242436f945e048e86a9d6707f057faa65e308c75252bd2c12R88-R135)

### Dependency and Import Updates

* Added necessary imports for `TokenCredential` and `Configurable` to support custom credential provider functionality. [[1]](diffhunk://#diff-735aaa86864f9c1242436f945e048e86a9d6707f057faa65e308c75252bd2c12R6) [[2]](diffhunk://#diff-735aaa86864f9c1242436f945e048e86a9d6707f057faa65e308c75252bd2c12L15-R17) [[3]](diffhunk://#diff-1b81f4e8e862f02e9ed174d88de1f50ea52024e819f697191c111676955b168dR6)
# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md).**

## [General Guidelines and Best Practices](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md#developer-guide)
- [x] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md#building-and-unit-testing)
- [ ] Pull request includes test coverage for the included changes.
