### PR TITLE
Do not log SinkRecord contents in CosmosSinkTask exception (CC-42195)

### DIFF
--- a/sdk/cosmos/azure-cosmos-kafka-connect/src/main/java/com/azure/cosmos/kafka/connect/implementation/sink/CosmosSinkTask.java
+++ b/sdk/cosmos/azure-cosmos-kafka-connect/src/main/java/com/azure/cosmos/kafka/connect/implementation/sink/CosmosSinkTask.java
@@ -104,7 +104,15 @@ public class CosmosSinkTask extends SinkTask {
                                         .getOrDefault(record.topic(), StringUtils.EMPTY)));
 
         if (recordsByContainer.containsKey(StringUtils.EMPTY)) {
-            throw new IllegalStateException("There is no container defined for topics " + recordsByContainer.get(StringUtils.EMPTY));
+            // Only include the offending topic names in the message. Interpolating the SinkRecord list
+            // would call SinkRecord.toString(), leaking record keys/values (customer payloads) into ERROR logs.
+            List<String> topicsWithoutContainer =
+                recordsByContainer.get(StringUtils.EMPTY)
+                    .stream()
+                    .map(SinkRecord::topic)
+                    .distinct()
+                    .collect(Collectors.toList());
+            throw new IllegalStateException("There is no container defined for topics " + topicsWithoutContainer);
         }
 
         for (Map.Entry<String, List<SinkRecord>> entry : recordsByContainer.entrySet()) {


### PR DESCRIPTION
  ## Summary
  `CosmosSinkTask.put()` could leak full customer record payloads (keys and values) into connect-worker ERROR logs. This fixes the leak at the source by building the exception message from topic names only.

  Security: INC-11697 / CC-42195 (Critical).

  ## Root cause
  When a record's topic has no entry in the topic→container map, `put()` buckets it under the empty-string key and throws:

  ```java
  throw new IllegalStateException(
      "There is no container defined for topics " + recordsByContainer.get(StringUtils.EMPTY));
  ```

  `recordsByContainer.get(StringUtils.EMPTY)` is a `List<SinkRecord>`. String concatenation invokes `List.toString()` → `SinkRecord.toString()`, which renders the record **key and value**. The exception leaves `put()` uncaught, and Kafka Connect's `WorkerSinkTask` logs failed
  `put()` calls at ERROR — so full message payloads for any mis-mapped topic land in the worker logs (and are typically shipped to centralized logging).

  ## Fix
  Build the message from the offending **distinct topic names** only — never the records:

  ```java
  List<String> topicsWithoutContainer =
      recordsByContainer.get(StringUtils.EMPTY)
          .stream()
          .map(SinkRecord::topic)
          .distinct()
          .collect(Collectors.toList());
  throw new IllegalStateException("There is no container defined for topics " + topicsWithoutContainer);
  ```

  The exception type, throw site, and control flow are unchanged; only the message contents change. The topic names preserve the diagnostic value (operators still see which topics lack a container mapping) without exposing any record data.

  ## Scope / risk
  - One file, +9/−1 (`CosmosSinkTask.java`). No behavioral change beyond the message.
  - No public API or config change.

  ## Testing
  - `mvn compile` and the existing `unit` suite pass (`mvn verify -Punit`: all green).
  - Verified by inspection that no `SinkRecord` (or `List<SinkRecord>`) reaches a log or exception string in this path after the change.

  ## References
  - INC-11697 — Customer record logged in CosmosSinkTask via thrown exception at ERROR
  - CC-42195 — CosmosSinkTask logs full SinkRecord (key + value) via thrown exception at ERROR
