### PR TITLE
Do not log Kafka record key in CosmosDbSink logs (INC-11697)

### DIFF
--- a/sdk/cosmos/azure-cosmos-kafka-connect/src/main/java/com/azure/cosmos/kafka/connect/implementation/sink/CosmosBulkWriter.java
+++ b/sdk/cosmos/azure-cosmos-kafka-connect/src/main/java/com/azure/cosmos/kafka/connect/implementation/sink/CosmosBulkWriter.java
@@ -111,7 +111,7 @@ public class CosmosBulkWriter extends CosmosWriterBase {
                                 LOGGER.warn(
                                     "Could not upload record {} to CosmosDB after exhausting all retries, "
                                         + "but ToleranceOnErrorLevel is all, will only log the error message. ",
-                                    sinkOperation.getSinkRecord().key(),
+                                    getRecordContext(sinkOperation.getSinkRecord()),
                                     sinkOperation.getException());
                                 return Mono.empty();
                             } else {

--- a/sdk/cosmos/azure-cosmos-kafka-connect/src/main/java/com/azure/cosmos/kafka/connect/implementation/sink/CosmosPointWriter.java
+++ b/sdk/cosmos/azure-cosmos-kafka-connect/src/main/java/com/azure/cosmos/kafka/connect/implementation/sink/CosmosPointWriter.java
@@ -196,7 +196,7 @@ public class CosmosPointWriter extends CosmosWriterBase {
         Mono.just(this)
             .flatMap(data -> {
                 if (sinkOperation.getRetryCount() > 0) {
-                    LOGGER.debug("Retry for sinkRecord {}", sinkOperation.getSinkRecord().key());
+                    LOGGER.debug("Retry for sinkRecord {}", getRecordContext(sinkOperation.getSinkRecord()));
                 }
                 return execution.apply(sinkOperation);
             })
@@ -222,7 +222,7 @@ public class CosmosPointWriter extends CosmosWriterBase {
                     if (this.writeConfig.getToleranceOnErrorLevel() == ToleranceOnErrorLevel.ALL) {
                         LOGGER.warn(
                             "Could not upload record {} to CosmosDB after exhausting all retries, but ToleranceOnErrorLevel is all, will only log the error message. ",
-                            sinkOperation.getSinkRecord().key(),
+                            getRecordContext(sinkOperation.getSinkRecord()),
                             sinkOperation.getException());
                         return Mono.empty();
                     } else {

--- a/sdk/cosmos/azure-cosmos-kafka-connect/src/main/java/com/azure/cosmos/kafka/connect/implementation/sink/CosmosWriterBase.java
+++ b/sdk/cosmos/azure-cosmos-kafka-connect/src/main/java/com/azure/cosmos/kafka/connect/implementation/sink/CosmosWriterBase.java
@@ -82,6 +82,11 @@ public abstract class CosmosWriterBase implements IWriter {
         return KafkaCosmosExceptionsHelper.isTransientFailure(exception);
     }
 
+    // Identifies a record for diagnostics by topic-partition-offset, never by key/value (which may be customer PII - INC-11697).
+    protected static String getRecordContext(SinkRecord sinkRecord) {
+        return String.format("%s-%d@%d", sinkRecord.topic(), sinkRecord.kafkaPartition(), sinkRecord.kafkaOffset());
+    }
+
     protected void sendToDlqIfConfigured(SinkOperation sinkOperationContext) {
         if (this.errantRecordReporter != null) {
             errantRecordReporter.report(sinkOperationContext.getSinkRecord(), sinkOperationContext.getException());

--- a/sdk/cosmos/azure-cosmos-kafka-connect/src/main/java/com/azure/cosmos/kafka/connect/implementation/sink/SinkRecordTransformer.java
+++ b/sdk/cosmos/azure-cosmos-kafka-connect/src/main/java/com/azure/cosmos/kafka/connect/implementation/sink/SinkRecordTransformer.java
@@ -33,14 +33,15 @@ public class SinkRecordTransformer {
     public List<SinkRecord> transform(String containerName, List<SinkRecord> sinkRecords) {
         List<SinkRecord> toBeWrittenRecordList = new ArrayList<>();
         for (SinkRecord record : sinkRecords) {
-            if (record.key() != null) {
-                MDC.put(String.format("CosmosDbSink-%s", containerName), record.key().toString());
-            }
+            // Stamp a non-sensitive record identifier (topic-partition-offset) into the logging
+            // context for correlation - never the record key/value, which may be customer PII (INC-11697).
+            MDC.put(
+                String.format("CosmosDbSink-%s", containerName),
+                String.format("%s-%d@%d", record.topic(), record.kafkaPartition(), record.kafkaOffset()));
 
             LOGGER.trace(
-                "Key Schema [{}], Key [{}], Value type [{}], Value schema [{}]",
+                "Key Schema [{}], Value type [{}], Value schema [{}]",
                 record.keySchema(),
-                record.key(),
                 record.value() == null ? null : record.value().getClass().getName(),
                 record.value() == null ? null : record.valueSchema());
 


### PR DESCRIPTION
  ## Summary
  Stops the CosmosDbSink connector from logging the **Kafka record key** (potential customer PII) in connect-worker logs / OpenSearch. Log-statement-only change; no behavior change.

  Security: **INC-11697** (sibling to CC-42195, which fixed the `put()` exception value+key leak — already released in v0.74.0). The record key is customer-controlled and can contain PII, so
  it's treated as sensitive.

  ## Where the key was leaking
  - `SinkRecordTransformer` — `MDC.put("CosmosDbSink-<container>", record.key())`. The cloud log layout serializes MDC onto **every** log line on the worker thread (incl. the generic
  `CosmosWriterBase "Write failed."`), and it was never cleared.
  - `SinkRecordTransformer` — `LOGGER.trace(... "Key [{}]" ..., record.key(), ...)`.
  - `CosmosPointWriter` (`:199` retry, `:225` tolerance=all failure) and `CosmosBulkWriter` (`:114` tolerance=all failure) — logged `record.key()`.

  ## Fix
  - **MDC field kept, value made non-sensitive:** `CosmosDbSink-<container>` now carries `topic-partition@offset` instead of the key. This preserves log correlation (and any dashboards keyed
  on that field) without PII. Offset keeps it per-record-unique, and unlike the key it's never null or duplicated.
  - **TRACE:** dropped the key (keeps key schema + value type/schema).
  - **Retry/failure logs:** identify the record by `topic-partition@offset` via a shared `CosmosWriterBase.getRecordContext(SinkRecord)` helper instead of the key.

  ## Risk / scope
  - Pure logging change — no effect on writes, retries, partition keys, or error handling. Nothing in the connector (or anywhere in `confluentinc` per code search) reads the MDC field.
  - 4 files, log-statement-only.

  ## Testing
  - `mvn compile` clean; no `record.key()` remains in any log/MDC site in the connector.
  - `mvn verify -Punit` → **88 tests, 0 failures, BUILD SUCCESS**.

  ## References
  - INC-11697 — Customer record key logged in CosmosSinkTask/CosmosWriterBase via MDC
  - Related: CC-42195 (released v0.74.0)
