### PR TITLE
Add record locator to ProvidedInStrategy exception; tidy diagnostic comments

### DIFF
--- a/sdk/cosmos/azure-cosmos-kafka-connect/src/main/java/com/azure/cosmos/kafka/connect/implementation/sink/idstrategy/ProvidedInStrategy.java
+++ b/sdk/cosmos/azure-cosmos-kafka-connect/src/main/java/com/azure/cosmos/kafka/connect/implementation/sink/idstrategy/ProvidedInStrategy.java
@@ -33,10 +33,11 @@ class ProvidedInStrategy extends AbstractIdStrategy {
             Object object = JsonPath.parse(value).read(config.jsonPath());
             return sanitizeId(Values.convertToString(null, object));
         } catch (Exception e) {
-            // Do not attach the cause: the JsonPath exception message echoes the record body (customer PII - INC-11697).
-            // Keep the exception type for diagnostics, drop the body-bearing cause.
+            // Do not attach the cause: the JsonPath exception message can echo the record body (customer PII).
             throw new ConnectException(
-                "Could not evaluate JsonPath " + config.jsonPath() + " (" + e.getClass().getName() + ")");
+                "Could not evaluate JsonPath " + config.jsonPath()
+                    + " for record " + record.topic() + "-" + record.kafkaPartition() + "@" + record.kafkaOffset()
+                    + " (" + e.getClass().getName() + ")");
         }
     }
 

--- a/sdk/cosmos/azure-cosmos-kafka-connect/src/main/java/com/azure/cosmos/kafka/connect/implementation/sink/patch/KafkaCosmosPatchHelper.java
+++ b/sdk/cosmos/azure-cosmos-kafka-connect/src/main/java/com/azure/cosmos/kafka/connect/implementation/sink/patch/KafkaCosmosPatchHelper.java
@@ -119,7 +119,7 @@ public class KafkaCosmosPatchHelper {
             // As of today, we start with more restrict rules: throw exception if there is no operations being included in the patch operation
             // But in the future, if it is a common scenario that we will reach here,
             // we can consider to relax the rules by adding another config to allow this behavior in patch configs
-            // Identify the record by topic-partition-offset, not itemId (which is record-derived/PII - INC-11697).
+            // Use topic-partition-offset to identify the record; the Cosmos itemId is record-derived and may contain PII.
             throw new IllegalStateException(
                 "There is no operations included in the patch operation for record "
                     + sinkRecord.topic() + "-" + sinkRecord.kafkaPartition() + "@" + sinkRecord.kafkaOffset());


### PR DESCRIPTION
Follow-up to #59 (CC-42199/42200).

- **`ProvidedInStrategy`**: include the record's `topic-partition-offset` in the JsonPath-failure `ConnectException` message, so the failing record is locatable. Still no record body / no chained cause. (This locator was part of the intended CC-42200 fix but didn't land in #59's merge.)
- **Comments**: reworded the diagnostic comments in `ProvidedInStrategy` and `KafkaCosmosPatchHelper` to describe the code rather than the change.

No behavior change; `mvn compile` clean. Refs INC-11697 / CC-42200.